### PR TITLE
PLF-8129 - update default RTC configuration

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons.web-conferencing</groupId>
     <artifactId>web-conferencing</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-default_servers-SNAPSHOT</version>
   </parent>
   
   <artifactId>web-conferencing-packaging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   
   <groupId>org.exoplatform.addons.web-conferencing</groupId>
   <artifactId>web-conferencing</artifactId>
-  <version>1.2.x-SNAPSHOT</version>
+  <version>1.2.x-default_servers-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Web Conferencing</name>
   <description>eXo Web Conferencing portal extension</description>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons.web-conferencing</groupId>
     <artifactId>web-conferencing</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-default_servers-SNAPSHOT</version>
   </parent>
   
   <artifactId>web-conferencing-services</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons.web-conferencing</groupId>
     <artifactId>web-conferencing</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-default_servers-SNAPSHOT</version>
   </parent>
   
   <artifactId>web-conferencing-webapp</artifactId>

--- a/webrtc/pom.xml
+++ b/webrtc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons.web-conferencing</groupId>
     <artifactId>web-conferencing</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-default_servers-SNAPSHOT</version>
   </parent>
   <artifactId>webrtc-connector</artifactId>
   <packaging>pom</packaging>

--- a/webrtc/services/pom.xml
+++ b/webrtc/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons.web-conferencing</groupId>
     <artifactId>webrtc-connector</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-default_servers-SNAPSHOT</version>
   </parent>
   
   <artifactId>web-conferencing-webrtc-services</artifactId>

--- a/webrtc/services/src/main/java/org/exoplatform/webconferencing/webrtc/WebrtcProvider.java
+++ b/webrtc/services/src/main/java/org/exoplatform/webconferencing/webrtc/WebrtcProvider.java
@@ -469,8 +469,8 @@ public class WebrtcProvider extends CallProvider {
     // Log warning if default (aka public) ICE servers in use
     for (ICEServer ices : this.rtcConfiguration.getIceServers()) {
       if (ices.isEnabled() && ices.isDefault()) {
-        LOG.warn("Default ICE servers will be used for WebRTC calls: " + ices.getUrls().toString()
-            + ". Configure own set of servers and disable the default one.");
+        LOG.warn("Default eXo ICE servers will be used for WebRTC calls: " + ices.getUrls().toString()
+            + ". You can configure your own set of servers and disable the default one.");
       }
     }
 

--- a/webrtc/webapp/pom.xml
+++ b/webrtc/webapp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons.web-conferencing</groupId>
     <artifactId>webrtc-connector</artifactId>
-    <version>1.2.x-SNAPSHOT</version>
+    <version>1.2.x-default_servers-SNAPSHOT</version>
   </parent>
   
   <artifactId>web-conferencing-webrtc-webapp</artifactId>

--- a/webrtc/webapp/src/main/webapp/WEB-INF/conf/webrtc/configuration.xml
+++ b/webrtc/webapp/src/main/webapp/WEB-INF/conf/webrtc/configuration.xml
@@ -45,17 +45,28 @@
         <object-param>
           <name>rtc-configuration</name>
           <object type="org.exoplatform.webconferencing.webrtc.WebrtcProvider$RTCConfiguration">
-            <!-- Here we set default (out of the box) settings that can be changed in Admin UI -->
-            <!-- field name="bundlePolicy">
+            <!-- 
+              bundlePolicy parameter possible values : [ balanced | max-compat | max-bundle ] (default: balanced)
+              more details : https://www.w3.org/TR/webrtc/#dom-rtcbundlepolicy
+              -->
+            <field name="bundlePolicy">
               <string>balanced</string>
             </field>
+            <!-- 
+              iceCandidatePoolSize parameter (default: 0)
+              more details : https://www.w3.org/TR/webrtc/#dom-rtcconfiguration-icecandidatepoolsize
+              -->
             <field name="iceCandidatePoolSize">
               <int>0</int>
             </field>
+            <!-- 
+              iceTransportPolicy parameter possible values : [ all | relay ] (default: all)
+              more details : https://www.w3.org/TR/webrtc/#dom-rtcicetransportpolicy
+              -->
             <field name="iceTransportPolicy">
-              <string>all</string>
+              <string>${webconferencing.webrtc.iceTransportPolicy:all}</string>
             </field>
-            <field name="certificates">
+            <!-- field name="certificates">
               <collection type="java.util.ArrayList">
                 <value>
                   <object type="org.exoplatform.webconferencing.webrtc.WebrtcProvider$RTCCertificate">

--- a/webrtc/webapp/src/main/webapp/WEB-INF/conf/webrtc/configuration.xml
+++ b/webrtc/webapp/src/main/webapp/WEB-INF/conf/webrtc/configuration.xml
@@ -80,12 +80,12 @@
             <field name="iceServers">
               <collection type="java.util.LinkedHashSet">
                 <value>
-                  <!-- Pool of STUN servers for default use (development & testing) -->
+                  <!-- Pool of STUN servers for default use -->
                   <object type="org.exoplatform.webconferencing.webrtc.WebrtcProvider$DefaultICEServer">
                     <!-- 
                       It's default set of ICE servers. Default servers are public out of the box. 
-                      Don't use them in production. This will be warned in the server log. 
                       Instead define a new object in this configuration to configure own ICE servers set.
+                      This will be warned in the server log. 
                      -->
                     <field name="enabled">
                       <boolean>${webconferencing.webrtc.default.stun.enabled:true}</boolean>
@@ -93,12 +93,66 @@
                     <field name="urls">
                       <collection type="java.util.ArrayList">
                         <value>
-                          <string>stun:stun.l.google.com:19302</string>
-                        </value>
-                        <value>
-                          <string>stun:stunserver.org</string>
+                          <string>stun:stun.exoplatform.org:3478</string>
                         </value>
                       </collection>
+                    </field>
+                  </object>
+                </value>
+                <value>
+                  <!-- eXo STUN servers -->
+                  <object type="org.exoplatform.webconferencing.webrtc.WebrtcProvider$ICEServer">
+                    <field name="enabled">
+                      <boolean>${webconferencing.webrtc.exo.stun.enabled:false}</boolean>
+                    </field>
+                    <field name="urls">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>stun:stun.exoplatform.org:3478</string>
+                        </value>
+                        <!-- <value>
+                          <string>stun:stun.exoplatform.org:80</string>
+                        </value> -->
+                        <!-- <value>
+                          <string>stuns:stun.exoplatform.org:443</string>
+                        </value> -->
+                      </collection>
+                    </field>
+                  </object>
+                </value>
+                <!-- eXo TURN servers -->
+                <value>
+                  <object type="org.exoplatform.webconferencing.webrtc.WebrtcProvider$ICEServer">
+                    <field name="enabled">
+                      <boolean>${webconferencing.webrtc.exo.turn.enabled:false}</boolean>
+                    </field>
+                    <field name="urls">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>turn:turn.exoplatform.org:3478?transport=udp</string>
+                        </value>
+                        <value>
+                          <string>turn:turn.exoplatform.org:3478?transport=tcp</string>
+                        </value>
+                        <value>
+                          <string>turns:turn.exoplatform.org:5349?transport=tcp</string>
+                        </value>
+                        <!-- <value>
+                          <string>turn:turn.exoplatform.org:80?transport=udp</string>
+                        </value>
+                        <value>
+                          <string>turn:turn.exoplatform.org:80?transport=tcp</string>
+                        </value> -->
+                        <!-- <value>
+                          <string>turns:turn.exoplatform.org:443?transport=tcp</string>
+                        </value> -->
+                      </collection>
+                    </field>
+                    <field name="username">
+                      <string>${webconferencing.webrtc.exo.turn.username:}</string>
+                    </field>
+                    <field name="credential">
+                      <string>${webconferencing.webrtc.exo.turn.credential:}</string>
                     </field>
                   </object>
                 </value>


### PR DESCRIPTION
The objectives of this pull request are : 

- change default stun server from Google to eXo server
- provide an eXo STUN servers server group 

activate / deactivate the server group with `webconferencing.webrtc.exo.stun.enabled` eXo property (default: false)

- provide a configurable eXo TURN servers server group 

activate / deactivate the server group with `webconferencing.webrtc.exo.turn.enabled` eXo property (default: false)
configure the turn username with `webconferencing.webrtc.exo.turn.username` eXo property (default: EMPTY)
configure the turn credential with `webconferencing.webrtc.exo.turn.credential` eXo property (default: EMPTY)

- improve inline comments
- use default ICE values from the official standard (https://www.w3.org/TR/webrtc/#rtcconfiguration-dictionary)
	- bundlePolicy
	- iceCandidatePoolSize
	- iceTransportPolicy
- add a property `webconferencing.webrtc.iceTransportPolicy` to define iceTransportPolicy parameter (default: all)
