### PR TITLE
SWF-4705 : depends on PLF 5.2.x-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- Dependencies versions                    -->
     <!-- **************************************** -->
     <org.exoplatform.depmgt.version>15-SNAPSHOT</org.exoplatform.depmgt.version>
-    <org.exoplatform.platform.version>5.0.0-RC01</org.exoplatform.platform.version>
+    <org.exoplatform.platform.version>5.2.x-SNAPSHOT</org.exoplatform.platform.version>
     <!-- for tests -->
     <junit.version>4.12</junit.version>
   </properties>


### PR DESCRIPTION
This fix makes webconferencing project depends on the latest PLF version (5.2.x-SNAPSHOT).