### PR TITLE
ITOP-4128 fix dependency issue on translation builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,13 +109,6 @@
       </dependency>
       <!-- for tests -->
       <dependency>
-        <groupId>org.exoplatform</groupId>
-        <artifactId>exo-jcr-services</artifactId>
-        <version>${org.exoplatform.platform.version}</version>
-        <type>jar</type>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -96,13 +96,6 @@
       </dependency>
       <!-- for tests -->
       <dependency>
-        <groupId>org.exoplatform</groupId>
-        <artifactId>exo-jcr-services</artifactId>
-        <version>${org.exoplatform.platform.version}</version>
-        <type>jar</type>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>


### PR DESCRIPTION
The translation job replace the ``org.exoplatform.platform.version`` value by ``5.2.x-translation-SNAPSHOT`` during the build.
As In this project the same value is used for platform and jcr dependencies and the jcr project is not translated, the build is failing due to a not existing dependency on ``exo-jcr-services:5.2.x-translation-SNAPSHOT``
If we use a different variable not replaced by the job [(list here)](https://github.com/exoplatform/swf-jenkins-pipeline-libs/blob/master/vars/exoPLFTranslation.groovy#L89), the build should success.