### PR TITLE
TASK-40870 retrieve call URL when call updating

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing.js
+++ b/webapp/src/main/webapp/js/webconferencing.js
@@ -2333,7 +2333,13 @@
           cometd.remoteCall("/webconferencing/calls", callProps, function(response) {
             var result = tryParseJson(response);
             if (response.successful) {
-              process.resolve(result);
+              self.getProvider(stateInfo.provider)
+                .then(provider => {
+                  if (provider.getCallUrl) {
+                    result.url = provider.getCallUrl(id);
+                  }
+                  process.resolve(result);
+                });
             } else {
               process.reject(result);
             }


### PR DESCRIPTION
When call updating, the call URL isn't retrieved in CallInfo, which is made when creating a call only.
This PR will build the call URL when updating as doing for creating a web conferencing call.