### PR TITLE
TASK-26265 centralize third party libraries versions in maven-depmgt-pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,6 @@
     <addon.exo.jcr.version>6.2.x-SNAPSHOT</addon.exo.jcr.version>
     <org.exoplatform.social.version>6.2.x-SNAPSHOT</org.exoplatform.social.version>
     <org.exoplatform.platform-ui.version>6.2.x-SNAPSHOT</org.exoplatform.platform-ui.version>
-
-    <!-- for tests -->
-    <junit.version>4.12</junit.version>
-    <io.jsonwebtoken.version>0.10.5</io.jsonwebtoken.version>
   </properties>
 
   <dependencyManagement>
@@ -99,67 +95,38 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.exoplatform.jcr</groupId>
+        <artifactId>jcr-parent</artifactId>
+        <version>${addon.exo.jcr.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Video Calls extension -->
       <dependency>
-        <groupId>org.exoplatform.addons.web-conferencing</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>web-conferencing-services</artifactId>
         <version>${project.version}</version>
         <type>jar</type>
       </dependency>
       <dependency>
-        <groupId>org.exoplatform.addons.web-conferencing</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>web-conferencing-webapp</artifactId>
         <version>${project.version}</version>
         <type>war</type>
       </dependency>
       <!-- WebRTC extension -->
       <dependency>
-        <groupId>org.exoplatform.addons.web-conferencing</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>web-conferencing-webrtc-services</artifactId>
         <version>${project.version}</version>
         <type>jar</type>
       </dependency>
       <dependency>
-        <groupId>org.exoplatform.addons.web-conferencing</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>web-conferencing-webrtc-webapp</artifactId>
         <version>${project.version}</version>
         <type>war</type>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-api</artifactId>
-        <version>${io.jsonwebtoken.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-impl</artifactId>
-        <version>${io.jsonwebtoken.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-jackson</artifactId>
-        <version>${io.jsonwebtoken.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.jcr</groupId>
-        <artifactId>exo.jcr.component.core</artifactId>
-        <version>${addon.exo.jcr.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.jcr</groupId>
-        <artifactId>exo.jcr.component.ext</artifactId>
-        <version>${addon.exo.jcr.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- for tests -->
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR will :
* centralise jar dependencies in order to ensure jar versions coherence between all projects and avoid bad jar versions in runtime. This will ease the maintenance and update of jar dependencies as well.
