### PR TITLE
MAINT-48477: Fix recording save of jitsi meet when it's launched from agenda event

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2317,7 +2317,7 @@ public class WebConferencingService implements Startable {
     // TODO use the user session, not a system session
     SessionProvider sessionProvider = sessionProviders.getSystemSessionProvider(null);
     Session session = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
-    if (OWNER_TYPE_SPACE.equals(type)) {
+    if (OWNER_TYPE_SPACE.equals(type) || OWNER_TYPE_SPACEEVENT.equals(type)) {
       Node rootSpace = null;
       Space space = spaceService.getSpaceByPrettyName(identity);
       rootSpace = (Node) session.getItem(nodeCreator.getJcrPath(CMS_GROUPS_PATH) + space.getGroupId());


### PR DESCRIPTION
**ISSUE**: When the type of the upload is space_event the recording folder Node was pointing on the userPrivate node folder because of an non handled case which ends with an **access denied jcr exception** as it's not pointing on space/Documents Node folder.
**FIX**: Correct the condition by handling the space_event upload type when getting the rootNode of the recordings folder to save the records.