### PR TITLE
TASK-42611 : fixed meeting recording being saved in last participating user recording folder (#58)

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2063,7 +2063,7 @@ public class WebConferencingService implements Startable {
         final String uploadingUser = uploadInfo.getUser();
         String owner = null;
         // Owner is user if it's not a space, otherwise use space identity
-        if (!uploadInfo.getType().equals(OWNER_TYPE_SPACE) && !uploadInfo.getIdentity().equals(uploadingUser)) {
+        if (!uploadInfo.getType().equals(OWNER_TYPE_SPACEEVENT) && !uploadInfo.getType().equals(OWNER_TYPE_SPACE) && !uploadInfo.getIdentity().equals(uploadingUser)) {
           owner = uploadingUser;
         } else {
           owner = uploadInfo.getIdentity();


### PR DESCRIPTION
Before this fix , the recording of a meeting is always saved in the recording folder related to the last participating user in the call , so i fixed this by altering the condition that determines where the recording has to be saved so that it takes in charge the "space-event" meeting type.