### PR TITLE
Task-48693: Agenda event planned jitsi call isn't launched when space name is edited afterwards

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -243,9 +243,7 @@ public class WebConferencingService implements Startable {
       super(spaceIdentity.getId(), spaceIdentity.getRemoteId());
       Space space = spaceService.getSpaceByPrettyName(spaceIdentity.getRemoteId());
       this.profileLink = space.getUrl();
-      String avatar = space.getAvatarUrl();
-      avatar = avatar != null ? avatar : LinkProvider.SPACE_DEFAULT_AVATAR_URL;
-      this.avatarLink = avatar;
+      this.avatarLink = space.getAvatarUrl() != null ? space.getAvatarUrl() : LinkProvider.SPACE_DEFAULT_AVATAR_URL;
       this.groupId = space.getGroupId();
     }
 

--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -238,9 +238,10 @@ public class WebConferencingService implements Startable {
      * Instantiates a new space event info.
      *
      * @param socialSpace the social space
+     * @param spaceIdentityId the space identity id
      */
-    public SpaceEventInfo(Space socialSpace) {
-      super(socialSpace.getPrettyName(), socialSpace.getDisplayName());
+    public SpaceEventInfo(Space socialSpace, String spaceIdentityId) {
+      super(spaceIdentityId, socialSpace.getDisplayName());
       this.groupId = socialSpace.getGroupId();
     }
 
@@ -576,7 +577,7 @@ public class WebConferencingService implements Startable {
    * moment of invocation. Even participants will be resolved from the owner and
    * given spaces' members plus given participants IDs.
    *
-   * @param spacePrettyName the space pretty name
+   * @param spaceIdentityId the space identity id
    * @param partIds the participants IDs (attendees) added to the event directly
    * @param spacesPrettyName the Social spaces' pretty names for add its members as
    *          participants (attendees) to the event
@@ -584,10 +585,10 @@ public class WebConferencingService implements Startable {
    * @throws IdentityStateException the identity state exception
    * @throws StorageException the storage exception
    */
-  public SpaceEventInfo getSpaceEventInfo(String spacePrettyName, String[] partIds, String[] spacesPrettyName)
+  public SpaceEventInfo getSpaceEventInfo(String spaceIdentityId, String[] partIds, String[] spacesPrettyName)
                                                                                                      throws IdentityStateException,
                                                                                                      StorageException {
-    return spaceEventInfo(spacePrettyName, findLastSpaceEventCallId(spacePrettyName), partIds, spacesPrettyName);
+    return spaceEventInfo(spaceIdentityId, findLastSpaceEventCallId(spaceIdentityId), partIds, spacesPrettyName);
   }
 
   /**
@@ -639,7 +640,7 @@ public class WebConferencingService implements Startable {
   protected SpaceEventInfo spaceEventInfo(String spaceIdentityId, String callId, String[] participants, String[] spaces) throws IdentityStateException {
     Identity spaceIdentity = socialIdentityManager.getIdentity(spaceIdentityId);
     Space socialSpaceHost = spaceService.getSpaceByPrettyName(spaceIdentity.getRemoteId());
-    SpaceEventInfo spaceEvent = new SpaceEventInfo(socialSpaceHost);
+    SpaceEventInfo spaceEvent = new SpaceEventInfo(socialSpaceHost, spaceIdentityId);
     
     // Merge the host space, given spaces and participants.
     Set<String> allSpaces = new LinkedHashSet<>();
@@ -1169,7 +1170,7 @@ public class WebConferencingService implements Startable {
       Identity spaceIdentity = socialIdentityManager.getIdentity(ownerId);
       Space space = spaceService.getSpaceByPrettyName(spaceIdentity.getRemoteId());
       if (space != null) {
-        owner = new SpaceEventInfo(space);
+        owner = new SpaceEventInfo(space, ownerId);
         owner.setProfileLink(space.getUrl());
         String avatar = space.getAvatarUrl();
         avatar = avatar != null ? avatar : LinkProvider.SPACE_DEFAULT_AVATAR_URL;

--- a/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
@@ -65,9 +65,6 @@ import io.swagger.annotations.ApiResponses;
 @Produces(MediaType.APPLICATION_JSON)
 public class RESTWebConferencingService implements ResourceContainer {
 
-  /** The Constant EMPTY. */
-  public static final String             EMPTY = "".intern();
-
   /** The Constant LOG. */
   protected static final Log             LOG   = ExoLogger.getLogger(RESTWebConferencingService.class);
 
@@ -365,12 +362,12 @@ public class RESTWebConferencingService implements ResourceContainer {
    * Gets the space event info.
    *
    * @param uriInfo the uri info
-   * @param spaceName the space name
+   * @param spaceIdentityId the space identity id
    * @return the space event info response
    */
     @GET
     @RolesAllowed("users")
-    @Path("/space-event/{spaceName}")
+    @Path("/space-event/{spaceIdentityId}")
     @ApiOperation(value = "Return a Social space event information", httpMethod = "GET", response = GroupInfo.class, 
       notes = "Use this method to read a Social space event used as call origin. This operation is avalable to all Platform users.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Request fulfilled. Space event info object returned.", response = GroupInfo.class),
@@ -382,17 +379,17 @@ public class RESTWebConferencingService implements ResourceContainer {
       @ApiResponse(code = 404, message = "Space not found or not accessible. Error code: " + ErrorInfo.CODE_NOT_FOUND_ERROR),
       @ApiResponse(code = 500, message = "Internal server error due to data reading from DB, its encoding or formatting result to JSON. Error code: " + ErrorInfo.CODE_SERVER_ERROR)})
     public Response getSpaceEventInfo(@Context UriInfo uriInfo,
-                                      @ApiParam(value = "Space pretty name used as the event host, ex: 'sales_team'", required = true) @PathParam("spaceName") String spaceName,
+                                      @ApiParam(value = "Space pretty name used as the event host, ex: 'sales_team'", required = true) @PathParam("spaceIdentityId") String spaceIdentityId,
                                       @ApiParam(value = "Participants directly invited to the event, a string of comma-separated names, ex: 'john,mary,james'", required = true) @QueryParam("participants") String participants,
                                       @ApiParam(value = "Space pretty names for inviting its participants to the event, a string of comma-separated names, ex: 'sales_team,acme_project,ux_pride'", required = true) @QueryParam("spaces") String spaces) {
       ConversationState convo = ConversationState.getCurrent();
       if (convo != null) {
         String currentUserName = convo.getIdentity().getUserId();
-        if (spaceName != null && spaceName.length() > 0) {
+        if (spaceIdentityId != null && spaceIdentityId.length() > 0) {
           if (participants != null && participants.length() > 0) {
             if (spaces != null && spaces.length() > 0) {
               try {
-                GroupInfo space = webConferencing.getSpaceEventInfo(spaceName,
+                GroupInfo space = webConferencing.getSpaceEventInfo(spaceIdentityId,
                                                                     participants.trim().split(";"),
                                                                     spaces.trim().split(";"));
                 if (space != null) {
@@ -411,22 +408,22 @@ public class RESTWebConferencingService implements ResourceContainer {
                                  .build();
                 }
               } catch (IdentityStateException e) {
-                LOG.error("Error reading member of space '" + spaceName + "' by '" + currentUserName + "'", e);
+                LOG.error("Error reading member of space with id'" + spaceIdentityId + "' by '" + currentUserName + "'", e);
                 return Response.serverError()
                                .cacheControl(cacheControl)
-                               .entity(ErrorInfo.serverError("Error reading member of space '" + spaceName + "'"))
+                               .entity(ErrorInfo.serverError("Error reading member of space with id'" + spaceIdentityId + "'"))
                                .build();
               } catch (StorageException e) {
-                LOG.error("Storage error for space event info of '" + spaceName + "' by '" + currentUserName + "'", e);
+                LOG.error("Storage error for space event info of space with id'" + spaceIdentityId + "' by '" + currentUserName + "'", e);
                 return Response.serverError()
                                .cacheControl(cacheControl)
-                               .entity(ErrorInfo.serverError("Storage error for space '" + spaceName + "'"))
+                               .entity(ErrorInfo.serverError("Storage error for space with id'" + spaceIdentityId + "'"))
                                .build();
               } catch (Throwable e) {
-                LOG.error("Error reading space event info of '" + spaceName + "' by '" + currentUserName + "'", e);
+                LOG.error("Error reading space event info of space with id'" + spaceIdentityId + "' by '" + currentUserName + "'", e);
                 return Response.serverError()
                                .cacheControl(cacheControl)
-                               .entity(ErrorInfo.serverError("Error reading space " + spaceName))
+                               .entity(ErrorInfo.serverError("Error reading space with id" + spaceIdentityId))
                                .build();
               }
             } else {


### PR DESCRIPTION
Prior to this fix, we couldn't lunch a scheduled jitsi call in a space event after renaming the space.
To fix this problem we need to use the space identity id as ownerId instead of the spacePrettyName