### PR TITLE
MAINT-50185: Fix the display of a blank page when launch a Jitsi call…

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing.js
+++ b/webapp/src/main/webapp/js/webconferencing.js
@@ -1556,7 +1556,7 @@
           cometd.remoteCall("/webconferencing/calls", callProps, function(response) {
             var result = tryParseJson(response);
             if (response.successful) {
-              self.getProvider(stateInfo.provider)
+              self.getProvider(result.providerType)
                 .then(provider => {
                   if (provider.getCallUrl) {
                     result.url = provider.getCallUrl(id);


### PR DESCRIPTION
**ISSUE**: When the state of the call is stopped the call wasn't able to continue the start after updating its state
because of a wrong passed argument for the `getProvider() function` in the comdetd request response resolving.
**FIX**: Set the right parameter for the `getProvider() function` to allow resolving the promise correctly when start the call