### PR TITLE
MAINT-51281: Initialize started jitsi calls state and participants status on each start up of the server (#77)

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -52,6 +52,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.lang.RandomStringUtils;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.picocontainer.Startable;
@@ -1193,6 +1195,37 @@ public class WebConferencingService implements Startable {
       return findCallById(id, true);
     } catch (CallSettingsException | CallOwnerException | StorageException | IdentityStateException e) {
       throw new InvalidCallException("Error getting call: " + id, e);
+    }
+  }
+
+  /**
+   * initialize all saved started calls state.
+   */
+
+  public void initializeStartedCallsState() {
+    try {
+      List<CallEntity> savedCalls = callStorage.findCallsByState(CallState.STARTED);
+      if (!savedCalls.isEmpty()) {
+        savedCalls.stream().forEach(callEntity -> {
+          try {
+            CallInfo callInfo = readCallEntity(callEntity, true);
+            callInfo.getParticipants().stream()
+                    .filter(participant -> participant.getState().equals(UserState.JOINED))
+                    .forEach(joinedUser -> {
+                      try {
+                        leaveCall(callInfo.getId(), joinedUser.getId(), joinedUser.getClientId());
+                      } catch (InvalidCallException e) {
+                        LOG.error("Error while updating participant {} state in call {}", joinedUser.getId(), callInfo.getId());
+                      }
+                    });
+            stopCall(callInfo.getId(), false);
+          } catch (Exception e) {
+            LOG.error("Error while reading call entity", e);
+          }
+        });
+      }
+    } catch (Exception e) {
+      LOG.error("Error while getting saved started calls");
     }
   }
 
@@ -2389,17 +2422,21 @@ public class WebConferencingService implements Startable {
   public void start() {
     // XXX we need reference SpaceService after the container start only, otherwise the servr startup fails
     this.spaceService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(SpaceService.class);
-
     // For a case when calls was active and server stopped, then calls wasn't marked as Stopped and need
     // remove them.
     LOG.info("Web Conferencing service started.");
+    PortalContainer container = PortalContainer.getInstance();
+    RequestLifeCycle.begin(container);
     try {
       int cleaned = deleteAllUserCalls();
       if (cleaned > 0) {
         LOG.info("Cleaned " + cleaned + " expired user calls.");
       }
+      initializeStartedCallsState();
     } catch (Throwable e) {
       LOG.warn("Error cleaning calls from previous server execution", e);
+    } finally {
+      RequestLifeCycle.end();
     }
   }
 
@@ -3443,7 +3480,7 @@ public class WebConferencingService implements Startable {
    *
    * @return number of deleted calls
    * @throws StorageException if storage error happens
-   * 
+   *
    */
   protected int deleteAllUserCalls() throws StorageException {
     try {

--- a/services/src/main/java/org/exoplatform/webconferencing/dao/CallDAO.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/dao/CallDAO.java
@@ -143,6 +143,22 @@ public class CallDAO extends GenericDAOJPAImpl<CallEntity, String> {
   }
 
   /**
+   * Find all calls by specific state
+   *
+   * @param state
+   * @return list of calls, or empty list if no matched result
+   */
+  public List<CallEntity> findCallsByState(String state) {
+    TypedQuery<CallEntity> query = getEntityManager().createNamedQuery("WebConfCall.findCallsByState", CallEntity.class)
+            .setParameter("state", state);
+    try {
+      return query.getResultList();
+    } catch (NoResultException e) {
+      return Collections.emptyList();
+    }
+  }
+
+  /**
    * Delete all users calls older of {@value #USER_CALL_DAYS_LIVETIME} days.
    *
    * @return the int number of actually removed calls

--- a/services/src/main/java/org/exoplatform/webconferencing/domain/CallEntity.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/domain/CallEntity.java
@@ -49,7 +49,10 @@ import org.exoplatform.webconferencing.WebConferencingService;
     @NamedQuery(name = "WebConfCall.findUserGroupCalls",
                 query = "SELECT c FROM WebConfCall c, WebConfParticipant p WHERE c.id = p.callId AND p.id = :userId ORDER BY c.lastDate"),
     @NamedQuery(name = "WebConfCall.deleteOwnerOlderCalls",
-                query = "DELETE FROM WebConfCall WHERE ownerType = :ownerType AND lastDate <= :expiredDate") })
+                query = "DELETE FROM WebConfCall WHERE ownerType = :ownerType AND lastDate <= :expiredDate"),
+        @NamedQuery(name = "WebConfCall.findCallsByState",
+                query = "SELECT c FROM WebConfCall c WHERE c.state = :state")})
+
 public class CallEntity {
 
   /** The id. */


### PR DESCRIPTION
…
ISSUE: persistent Join state on the calls in rooms still affect the old rooms even after fixing the root cause (the blank page after call launch fail)
FIX: We decided to update and initialize the remaining started calls and the participants state eventually on each server startup to fix this issue and for future unexpected incidents of this type.