### PR TITLE
MAINT-51942: Clean up jitsi started group calls on server startup

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/dao/CallDAO.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/dao/CallDAO.java
@@ -28,8 +28,10 @@ import java.util.List;
 
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
+import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
+import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.webconferencing.domain.CallEntity;
 
@@ -156,6 +158,35 @@ public class CallDAO extends GenericDAOJPAImpl<CallEntity, String> {
                              .setParameter("ownerType", OWNER_TYPE_USER)
                              .setParameter("expiredDate", Timestamp.valueOf(expired))
                              .executeUpdate();
+  }
+  /**
+   * Find all group calls by specific state
+   *
+   * @param state
+   * @return list of group calls, or empty list if no matched result
+   */
+  public List<CallEntity> findGroupCallsByState(String state) {
+    TypedQuery<CallEntity> query = getEntityManager().createNamedQuery("WebConfCall.findGroupCallsByState", CallEntity.class)
+            .setParameter("state", state);
+    try {
+      return query.getResultList();
+    } catch (NoResultException e) {
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Update Call state
+   *
+   * @param state
+   * @return Number of updated calls
+   */
+  @ExoTransactional
+  public int updateStartedCallState(String state) {
+    Query query = getEntityManager().createQuery("UPDATE WebConfCall c SET c.state = :state  WHERE c.state = 'started'")
+            .setParameter("state", state);
+
+    return query.executeUpdate();
   }
 
   /**

--- a/services/src/main/java/org/exoplatform/webconferencing/dao/ParticipantDAO.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/dao/ParticipantDAO.java
@@ -23,8 +23,10 @@ import java.util.List;
 
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
+import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
+import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.webconferencing.domain.ParticipantEntity;
 import org.exoplatform.webconferencing.domain.ParticipantId;
@@ -77,6 +79,21 @@ public class ParticipantDAO extends GenericDAOJPAImpl<ParticipantEntity, Partici
   @Deprecated // TODO not used
   public int deleteCallParts(String callId) throws PersistenceException, IllegalStateException, IllegalArgumentException {
     return getEntityManager().createNamedQuery("WebConfCall.deleteCallParts").setParameter("callId", callId).executeUpdate();
+  }
+
+  /**
+   * Update Participant state by call id
+   *
+   * @param state
+   * @return Number of updated participants
+   */
+  @ExoTransactional
+  public int updateParticipantStateByCallId(String state, String callId) {
+    Query query = getEntityManager().createQuery("UPDATE WebConfParticipant p SET p.state = :state  WHERE p.callId = :callId")
+            .setParameter("state", state)
+            .setParameter("callId", callId);
+
+    return query.executeUpdate();
   }
 
   /**

--- a/services/src/main/java/org/exoplatform/webconferencing/domain/CallEntity.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/domain/CallEntity.java
@@ -19,6 +19,7 @@
 package org.exoplatform.webconferencing.domain;
 
 import static org.exoplatform.webconferencing.WebConferencingService.OWNER_TYPE_SPACEEVENT;
+import static org.exoplatform.webconferencing.WebConferencingService.OWNER_TYPE_USER;
 
 import java.util.Date;
 
@@ -49,7 +50,9 @@ import org.exoplatform.webconferencing.WebConferencingService;
     @NamedQuery(name = "WebConfCall.findUserGroupCalls",
                 query = "SELECT c FROM WebConfCall c, WebConfParticipant p WHERE c.id = p.callId AND p.id = :userId ORDER BY c.lastDate"),
     @NamedQuery(name = "WebConfCall.deleteOwnerOlderCalls",
-                query = "DELETE FROM WebConfCall WHERE ownerType = :ownerType AND lastDate <= :expiredDate") })
+                query = "DELETE FROM WebConfCall WHERE ownerType = :ownerType AND lastDate <= :expiredDate"),
+    @NamedQuery(name = "WebConfCall.findGroupCallsByState",
+                query = "SELECT c FROM WebConfCall c WHERE c.state = :state AND c.ownerType != '" + OWNER_TYPE_USER + "'")})
 public class CallEntity {
 
   /** The id. */


### PR DESCRIPTION
**ISSUE**: Some launched group  calls stays on join state for unexpected reasons which leads to a wrong information for the user
**FIX**: Do a clean up of jitsi started group calls