### PR TITLE
Task-54582: Close button does not work when call is finished

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing.js
+++ b/webapp/src/main/webapp/js/webconferencing.js
@@ -2024,6 +2024,6 @@
 	});
 
 	log.trace("< Loaded at " + location.origin + location.pathname);
-	
+	webConferencing.closeWindow = function(){window.close();};
 	return webConferencing;
 })($, cCometD);


### PR DESCRIPTION
ISSUE: close button in exit screen for mobile doesn't work
FIX: added a close method to the webConferencing object, that we will use in jitsi-call module to close the call window