### PR TITLE
Task-54770 : Add secure and httpOnly option for cookie webconf_session_token

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/server/filter/SessionFilter.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/server/filter/SessionFilter.java
@@ -50,6 +50,8 @@ public class SessionFilter implements Filter {
       Cookie cookie = new Cookie(WebConferencingService.SESSION_TOKEN_COOKIE, sessionToken);
       cookie.setPath("/");
       cookie.setMaxAge(2400); // 40 mins
+      cookie.setHttpOnly(true);
+      cookie.setSecure(request.isSecure());
       httpRes.addCookie(cookie);
     }
 


### PR DESCRIPTION
Before this fix, the cookie webconf_session_token have no option secure nor httponly
This fix add theses options for this cookie