### PR TITLE
Task-53070 : When a recording upload fails, the error message is not clear

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -25,24 +25,10 @@ import java.net.URLEncoder;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.*;
 
 import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
@@ -901,7 +887,7 @@ public class WebConferencingService implements Startable {
                 }
               }
 
-              broacastCallEvent(EVENT_CALL_CREATED, call, currentUserId);
+              broacastCallEvent(EVENT_CALL_CREATED, call, currentUserId, null);
 
               // Log metrics - call created
               // service=notifications operation=send-push-notification
@@ -1245,7 +1231,7 @@ public class WebConferencingService implements Startable {
       String userId = currentUserId();
       try {
         stopCall(call, userId, remove);
-        broacastCallEvent(EVENT_CALL_STOPPED, call, userId);
+        broacastCallEvent(EVENT_CALL_STOPPED, call, userId, null);
 
         if (remove) {
           // Log metrics - call deleted
@@ -1316,7 +1302,7 @@ public class WebConferencingService implements Startable {
         String userId = currentUserId();
         startCall(call, userId, clientId, true);
 
-        broacastCallEvent(EVENT_CALL_STARTED, call, userId);
+        broacastCallEvent(EVENT_CALL_STARTED, call, userId, null);
 
         // Log metrics - call started
         LOG.info(metricMessage(userId, call, OPERATION_CALL_STARTED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
@@ -1572,7 +1558,7 @@ public class WebConferencingService implements Startable {
                                  partId,
                                  part.getId());
             }
-            broacastCallEvent(EVENT_CALL_JOINDED, call, partId);
+            broacastCallEvent(EVENT_CALL_JOINDED, call, partId, null);
 
             // Log metrics - call joined
             LOG.info(metricMessage(partId, call, OPERATION_CALL_JOINED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
@@ -1586,7 +1572,7 @@ public class WebConferencingService implements Startable {
           String userId = currentUserId();
           startCall(call, userId, clientId, false); // We will not notify parties about the auto-start
 
-          broacastCallEvent(EVENT_CALL_JOINDED, call, userId);
+          broacastCallEvent(EVENT_CALL_JOINDED, call, userId, null);
 
           // Log metrics - call started
           LOG.info(metricMessage(userId, call, OPERATION_CALL_STARTED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
@@ -1660,7 +1646,7 @@ public class WebConferencingService implements Startable {
                                  part.getId());
             }
 
-            broacastCallEvent(EVENT_CALL_LEFT, call, partId);
+            broacastCallEvent(EVENT_CALL_LEFT, call, partId, null);
             // Log metrics - call leaved
             LOG.info(metricMessage(partId, call, OPERATION_CALL_LEAVED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
             // Check if don't need stop the call if all parts leaved already
@@ -1673,7 +1659,7 @@ public class WebConferencingService implements Startable {
                 // but then need find a proper way of stopping the call if guests will not leave finally via API (network errors, server crashes etc).
                 stopCall(call, partId, false);
 
-                broacastCallEvent(EVENT_CALL_STOPPED, call, partId);
+                broacastCallEvent(EVENT_CALL_STOPPED, call, partId, null);
                 // Log metrics - call stopped
                 LOG.info(metricMessage(partId,
                                        call,
@@ -1687,7 +1673,7 @@ public class WebConferencingService implements Startable {
               // For P2P we remove the call when one of parts stand alone
               stopCall(call, partId, true);
 
-              broacastCallEvent(EVENT_CALL_STOPPED, call, partId);
+              broacastCallEvent(EVENT_CALL_STOPPED, call, partId, null);
               // Log metrics - call deleted
               LOG.info(metricMessage(partId,
                                      call,
@@ -2089,8 +2075,10 @@ public class WebConferencingService implements Startable {
       throw new UploadFileException("Cannot create upload resource", e);
     }
     UploadResource resource = uploadService.getUploadResource(uploadId);
+    CallInfo call = null;
     try {
       if (resource.getStatus() == UploadResource.UPLOADED_STATUS) {
+        call = getCall(uploadInfo.getCallId());
         final String uploadingUser = uploadInfo.getUser();
         String owner = null;
         // Owner is user if it's not a space, otherwise use space identity
@@ -2107,18 +2095,16 @@ public class WebConferencingService implements Startable {
         } else {
           saveFile(rootNode, resource, uploadingUser, null);
         }
-        try {
-          CallInfo call = getCall(uploadInfo.getCallId());
-          LOG.info(metricMessage(uploadingUser, call, OPERATION_CALL_RECORDED, STATUS_OK, System.currentTimeMillis() - opStart, null, resource.getUploadedSize()));
-        } catch (InvalidCallException e) {
-          LOG.warn("Failed to build metric for " + OPERATION_CALL_RECORDED, e);
-        }
+        broacastCallEvent(EVENT_CALL_RECORDED, call, uploadingUser, resource.getUploadedSize(), STATUS_OK);
+        LOG.info(metricMessage(uploadingUser, call, OPERATION_CALL_RECORDED, STATUS_OK, System.currentTimeMillis() - opStart, null, resource.getUploadedSize()));
       } else {
-        throw new UploadFileException("The file " + resource.getFileName() + " cannot be uploaded. Status: "
-            + resource.getStatus());
+        throw new UploadFileException("The file " + resource.getFileName() + " cannot be uploaded. Status: " + resource.getStatus());
       }
+    } catch (InvalidCallException e) {
+      LOG.warn("Failed to build metric for " + OPERATION_CALL_RECORDED, e);
     } catch (Exception e) {
-      LOG.info(metricMessage(uploadInfo.getUser(), null, OPERATION_CALL_RECORDED, STATUS_NOT_OK, System.currentTimeMillis() - opStart, null, resource.getUploadedSize()));
+      broacastCallEvent(EVENT_CALL_RECORDED, call, uploadInfo.getUser(), resource.getUploadedSize(), STATUS_NOT_OK);
+      LOG.info(metricMessage(uploadInfo.getUser(), call, OPERATION_CALL_RECORDED, STATUS_NOT_OK, System.currentTimeMillis() - opStart, null, resource.getUploadedSize()));
       LOG.error("Failed while saving the uploaded file" + e.getMessage(), e);    }
     finally {
       uploadService.removeUploadResource(uploadId);
@@ -3903,14 +3889,25 @@ public class WebConferencingService implements Startable {
     return res.toString();
   }
 
-  private void broacastCallEvent(String eventName, CallInfo call, String userId) {
+  private void broacastCallEvent(String eventName, CallInfo call, String userId, Double fileSize, String status) {
     try {
-      listenerService.broadcast(eventName, call, userId);
+      Map<String, String> info = new HashMap<>();
+      info.put("user_id", userId);
+      info.put("status", status);
+      if(fileSize != null) {
+        DecimalFormat df = new DecimalFormat("0.00");
+        String fileSizeByMO = df.format(fileSize / 1048576);
+        info.put("file_size", fileSizeByMO);
+      }
+      listenerService.broadcast(eventName, call, info);
     } catch (Exception e) {
       LOG.error("Error while broadcasting event '{}' for user '{}'", eventName, userId, e);
     }
   }
 
-  // <<<<<<< Call storage: wrappers to catch JPA exceptions
+  private void broacastCallEvent(String eventName, CallInfo call, String userId, Double fileSize) {
+    this.broacastCallEvent(eventName, call, userId, fileSize, STATUS_OK);
+  }
 
+  // <<<<<<< Call storage: wrappers to catch JPA exceptions
 }

--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -24,6 +24,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -161,6 +162,9 @@ public class WebConferencingService implements Startable {
 
   /** The status ok. */
   public static final String          STATUS_OK                    = "ok";
+
+  /** The status not ok. */
+  public static final String          STATUS_NOT_OK                = "ko";
 
   public static final String    EVENT_CALL_CREATED           = "exo.webconferencing.callCreated";
 
@@ -908,6 +912,7 @@ public class WebConferencingService implements Startable {
                                      OPERATION_CALL_ADDED,
                                      STATUS_OK,
                                      System.currentTimeMillis() - opStart,
+                                     null,
                                      null));
               return call;
             } else {
@@ -1244,10 +1249,10 @@ public class WebConferencingService implements Startable {
 
         if (remove) {
           // Log metrics - call deleted
-          LOG.info(metricMessage(userId, call, OPERATION_CALL_DELETED, STATUS_OK, System.currentTimeMillis() - opStart, null));
+          LOG.info(metricMessage(userId, call, OPERATION_CALL_DELETED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
         } else {
           // Log metrics - call stopped
-          LOG.info(metricMessage(userId, call, OPERATION_CALL_STOPPED, STATUS_OK, System.currentTimeMillis() - opStart, null));
+          LOG.info(metricMessage(userId, call, OPERATION_CALL_STOPPED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
         }
         return call;
       } catch (StorageException e) {
@@ -1314,7 +1319,7 @@ public class WebConferencingService implements Startable {
         broacastCallEvent(EVENT_CALL_STARTED, call, userId);
 
         // Log metrics - call started
-        LOG.info(metricMessage(userId, call, OPERATION_CALL_STARTED, STATUS_OK, System.currentTimeMillis() - opStart, null));
+        LOG.info(metricMessage(userId, call, OPERATION_CALL_STARTED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
         return call;
       } catch (StorageException | ParticipantNotFoundException | CallSettingsException e) {
         throw new InvalidCallException("Error starting call: " + callId, e);
@@ -1570,7 +1575,7 @@ public class WebConferencingService implements Startable {
             broacastCallEvent(EVENT_CALL_JOINDED, call, partId);
 
             // Log metrics - call joined
-            LOG.info(metricMessage(partId, call, OPERATION_CALL_JOINED, STATUS_OK, System.currentTimeMillis() - opStart, null));
+            LOG.info(metricMessage(partId, call, OPERATION_CALL_JOINED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
           } else {
             LOG.warn("Call join invoked but no participant was found for given user. Call ID: " + callId + ", participant: " + partId);
           }
@@ -1584,7 +1589,7 @@ public class WebConferencingService implements Startable {
           broacastCallEvent(EVENT_CALL_JOINDED, call, userId);
 
           // Log metrics - call started
-          LOG.info(metricMessage(userId, call, OPERATION_CALL_STARTED, STATUS_OK, System.currentTimeMillis() - opStart, null));
+          LOG.info(metricMessage(userId, call, OPERATION_CALL_STARTED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
         }
       } catch (CallSettingsException | ParticipantNotFoundException | StorageException e) {
         throw new InvalidCallException("Error joining call: " + callId, e);
@@ -1657,7 +1662,7 @@ public class WebConferencingService implements Startable {
 
             broacastCallEvent(EVENT_CALL_LEFT, call, partId);
             // Log metrics - call leaved
-            LOG.info(metricMessage(partId, call, OPERATION_CALL_LEAVED, STATUS_OK, System.currentTimeMillis() - opStart, null));
+            LOG.info(metricMessage(partId, call, OPERATION_CALL_LEAVED, STATUS_OK, System.currentTimeMillis() - opStart, null, null));
             // Check if don't need stop the call if all parts leaved already
             if (call.getOwner().isGroup()) {
               if (leavedNum == call.getParticipants().size() || call.getParticipants().size() == 0
@@ -1675,6 +1680,7 @@ public class WebConferencingService implements Startable {
                                        OPERATION_CALL_STOPPED,
                                        STATUS_OK,
                                        System.currentTimeMillis() - opStart,
+                                       null,
                                        null));
               }
             } else if (call.getParticipants().size() - leavedNum <= 1) {
@@ -1688,6 +1694,7 @@ public class WebConferencingService implements Startable {
                                      OPERATION_CALL_DELETED,
                                      STATUS_OK,
                                      System.currentTimeMillis() - opStart,
+                                     null,
                                      null));
             }
           } // else, if no one leaved, we don't need any action (it may be leaved an user of already stopped
@@ -2102,7 +2109,7 @@ public class WebConferencingService implements Startable {
         }
         try {
           CallInfo call = getCall(uploadInfo.getCallId());
-          LOG.info(metricMessage(uploadingUser, call, OPERATION_CALL_RECORDED, STATUS_OK, System.currentTimeMillis() - opStart, null));
+          LOG.info(metricMessage(uploadingUser, call, OPERATION_CALL_RECORDED, STATUS_OK, System.currentTimeMillis() - opStart, null, resource.getUploadedSize()));
         } catch (InvalidCallException e) {
           LOG.warn("Failed to build metric for " + OPERATION_CALL_RECORDED, e);
         }
@@ -2110,7 +2117,10 @@ public class WebConferencingService implements Startable {
         throw new UploadFileException("The file " + resource.getFileName() + " cannot be uploaded. Status: "
             + resource.getStatus());
       }
-    } finally {
+    } catch (Exception e) {
+      LOG.info(metricMessage(uploadInfo.getUser(), null, OPERATION_CALL_RECORDED, STATUS_NOT_OK, System.currentTimeMillis() - opStart, null, resource.getUploadedSize()));
+      LOG.error("Failed while saving the uploaded file" + e.getMessage(), e);    }
+    finally {
       uploadService.removeUploadResource(uploadId);
     }
   }
@@ -3861,7 +3871,8 @@ public class WebConferencingService implements Startable {
                                  String operation,
                                  String status,
                                  Long duration,
-                                 String error) {
+                                 String error,
+                                 Double fileSize) {
     StringBuilder res = new StringBuilder("service=webconferencing");
     res.append(" operation=").append(operation);
     res.append(" status=").append(status);
@@ -3873,6 +3884,11 @@ public class WebConferencingService implements Startable {
     res.append(", provider:").append(call.getProviderType());
     res.append(", state:").append(call.getState());
     res.append(", participantsCount:").append(call.getParticipants().size());
+    if(fileSize != null) {
+      DecimalFormat df = new DecimalFormat("0.00");
+      String fileSizeByMO = df.format(fileSize / 1048576);
+      res.append(", recording_file_size_in_mb:").append(fileSizeByMO);
+    }
     if (call.getLastDate() != null) {
       long callDurationSec = Math.round((System.currentTimeMillis() - call.getLastDate().getTime()) / 1000);
       res.append(", callDuration_sec:").append(callDurationSec);


### PR DESCRIPTION
Before this fix, when a recording upload fails due to size limit excedeed, we have a unclear message to say that upload fails
In addition, there was an error displayed in logs when the metric is computed, so that the metric was not saved
This commit improve the error message to clearly explain that the record file size exceed the upload limit and display this limit
It also fix the problem about the metric so that we can use it in graphana and aalytics