### PR TITLE
Task-55606 Update inviteId computation

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -37,7 +37,6 @@ import javax.jcr.Session;
 import javax.persistence.PersistenceException;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.codec.binary.StringUtils;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.exoplatform.commons.utils.CommonsUtils;


### PR DESCRIPTION
before this fix, the inviteId in call is a random string, which change when the call restart
To be able to invite guest in calendar event, we need to have standard inviteId, which is always the same, and not change during time
Thix fix update the inviteId computation by calculating it from the room name and using the AbstractCodec to compute it