### PR TITLE
Task-55718: Upload call record fail in some case.

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2177,10 +2177,9 @@ public class WebConferencingService implements Startable {
     }
 
     ManageableRepository repository = repositoryService.getCurrentRepository();
-    SessionProvider userProvider = sessionProviders.getSessionProvider(state);
-    sessionProviders.setSessionProvider(null, userProvider);
-    Session session = userProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
-    // Get node under user session
+    SessionProvider systemSessionProvider = sessionProviders.getSystemSessionProvider(null);
+    Session session = systemSessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
+    // Get node under system session
     Node folder = (Node) session.getItem(parent.getPath());
     Node recordingsFolder = getRecordingsFolder(folder);
 


### PR DESCRIPTION
Problem : This problem occurs when a guest (not a member in space) records a call in a specific space. because he has no access to this space and creates files or folders in app doc under this last.
Fix: In this fix instead of using user JCR session to manipulate nodes under app document we used system session to could anyone recoding call when he joins in call whatever he is a member in space or not.