### PR TITLE
Task-55606 : InviteId generation

### DIFF
--- a/services/src/main/resources/db/changelog/webconferencing.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/webconferencing.db.changelog-1.0.0.xml
@@ -150,14 +150,21 @@
         <constraints nullable="true" />
       </column>
       <column name="END_DATE" type="TIMESTAMP">
-        <constraints nullable="true" />
+        <constraints nullable="true"/>
       </column>
     </addColumn>
   </changeSet>
-  
+
   <!-- Alter WBC_CALLS table: remove constraint limiting to a single call per owner by group/user flag -->
   <changeSet author="web-conferencing" id="1.0.0-10">
-    <dropUniqueConstraint tableName="WBC_CALLS" constraintName="UK_WBC_GROUP_CALL" />
+    <dropUniqueConstraint tableName="WBC_CALLS" constraintName="UK_WBC_GROUP_CALL"/>
+  </changeSet>
+
+  <changeSet author="web-conferencing" id="1.0.0-11">
+    <modifyDataType tableName="WBC_INVITES"
+                    columnName="INVITATION_ID"
+                    newDataType="NVARCHAR(64)"
+    />
   </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Before this fix, when the inviteId is generated, the length of the new inviteId is not compatible with the length in database column
This commit add a modification to increase the length of the varchar in the correspondant column