### PR TITLE
Task-55606 : Update inviteId computation

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -45,6 +45,8 @@ import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.cms.documents.DocumentService;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+import org.exoplatform.web.security.codec.AbstractCodec;
+import org.exoplatform.web.security.codec.CodecInitializer;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.picocontainer.Startable;
@@ -400,6 +402,8 @@ public class WebConferencingService implements Startable {
   /** The Link manager. */
   protected final LinkManager                        linkManager;
 
+  private AbstractCodec                              codec;
+
   /**
    * Checks is ID valid (not null, not empty and not longer of {@value #ID_MAX_LENGTH} chars).
    *
@@ -489,7 +493,8 @@ public class WebConferencingService implements Startable {
                                 Authenticator authenticator,
                                 ShareDocumentService shareService,
                                 InitParams initParams,
-                                LinkManager linkManager) {
+                                LinkManager linkManager,
+                                CodecInitializer codecInitializer) {
     this.organization = organization;
     this.socialIdentityManager = socialIdentityManager;
     this.listenerService = listenerService;
@@ -508,6 +513,11 @@ public class WebConferencingService implements Startable {
     this.secretKey = jwtSecretParam.getProperty(SECRET_KEY);
     this.shareService = shareService;
     this.linkManager = linkManager;
+    try {
+      this.codec = codecInitializer.getCodec();
+    } catch (Exception e) {
+      LOG.error("Error initializing codecs", e);
+    }
   }
 
   protected UserInfo userInfo(String id) throws IdentityStateException {
@@ -2803,7 +2813,10 @@ public class WebConferencingService implements Startable {
    * @return the string with new invite ID
    */
   private String createInvite(String callId) {
-    String inviteId = RandomStringUtils.randomAlphabetic(12);
+    String inviteId = codec.encode(callId);
+    byte[] inviteIdBytes = Base64.getDecoder().decode(inviteId);
+    inviteId = Base64.getUrlEncoder().withoutPadding().encodeToString(inviteIdBytes);
+
     createInvite(callId, ALL_USERS, GROUP, inviteId);
     return inviteId;
   }

--- a/services/src/main/resources/db/changelog/webconferencing.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/webconferencing.db.changelog-1.0.0.xml
@@ -150,14 +150,21 @@
         <constraints nullable="true" />
       </column>
       <column name="END_DATE" type="TIMESTAMP">
-        <constraints nullable="true" />
+        <constraints nullable="true"/>
       </column>
     </addColumn>
   </changeSet>
-  
+
   <!-- Alter WBC_CALLS table: remove constraint limiting to a single call per owner by group/user flag -->
   <changeSet author="web-conferencing" id="1.0.0-10">
-    <dropUniqueConstraint tableName="WBC_CALLS" constraintName="UK_WBC_GROUP_CALL" />
+    <dropUniqueConstraint tableName="WBC_CALLS" constraintName="UK_WBC_GROUP_CALL"/>
+  </changeSet>
+
+  <changeSet author="web-conferencing" id="1.0.0-11">
+    <modifyDataType tableName="WBC_INVITES"
+                    columnName="INVITATION_ID"
+                    newDataType="NVARCHAR(64)"
+    />
   </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Before this fix, the inviteId in call is a random string, which change when the call restart
To be able to invite guest in calendar event, we need to have standard inviteId, which is always the same, and not change during time
Thix fix update the inviteId computation by calculating it from the room name and using the AbstractCodec to compute it