### PR TITLE
TASK-56197 : InviteID is null when I copy and paste the link of a webconference. (#128)

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2781,7 +2781,7 @@ public class WebConferencingService implements Startable {
         // Assume inviationId is the same for all invites in this call.
         return invites.get(0).getInvitationId();
       }
-      return null;
+      return createInvite(callId);
     } catch (IllegalArgumentException | IllegalStateException | PersistenceException e) {
       throw new StorageException("Error getting invite Id for call " + callId, e);
     }


### PR DESCRIPTION
ISSUES : InviteID is null when I copy and paste the link of a web conference.
FIX : the problem is that after closing the webconference, the inviteID will be deleted from the database, so when I reopen the link, the inviteID is null and fixed by create it every time I open the link of webconference.