### PR TITLE
TASK-56314 : Illustration: webnotification of call recording (#127)

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/listeners/CallRecordingNotificationListener.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/listeners/CallRecordingNotificationListener.java
@@ -79,7 +79,7 @@ public class CallRecordingNotificationListener extends Listener<CallInfo, Map<? 
                     avatarUrl += ident.getProfile().getAvatarUrl();
                 }
             } else {
-                name = identity;
+                name = callInfo.getTitle();
                 avatarUrl += "/chat/img/room-default.jpg";
             }
             for (String participant : participants) {


### PR DESCRIPTION
ISSUES : When we hover on the avatar of the notification recording of a room call, it displays the room ID instead of the room name.
FIX : the problem is that the room ID is displayed instead of the room name and it is fixed by getting the name of the chat room from callInfo.