### PR TITLE
Task-57307: Fix user popover when webRTC call is enabled

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/exoplatform/webconferencing"
   },
   "scripts": {
-    "watch": "webpack --config webpack.watch.js --progress --colors --watch -d",
+    "watch": "webpack --config webpack.dev.js --progress --colors --watch -d",
     "lint": "eslint --fix ./src/main/webapp/vue-apps/**/*.js  ./src/main/webapp/vue-apps/**/*.vue",
     "build": "webpack --config webpack.prod.js --mode production"
   },

--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
@@ -308,11 +308,16 @@ export default {
         }
       }
     }
-    a,
-    a:hover,
-    a:focus {
+    a {
       color: var(--allPagesDarkGrey, #4d5466) !important;
       letter-spacing: normal;
+    }
+    a:hover,
+    a:focus {
+      color: white !important;
+      i {
+        color: white !important;
+      }
     }
     [class^="call-button-container-"] {
       width: 100%;
@@ -340,7 +345,6 @@ export default {
   .VuetifyApp {
     .call-button-container {
       min-width: unset;
-      padding: 0 0 7px 0;
       &:hover {
         .dropdown-header {
           background-color: transparent;
@@ -399,7 +403,8 @@ export default {
     }
 
     .buttons-container {
-      top: 23px;
+      top: 27px;
+      right: -70px!important;
     }
   }
 }

--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/Dropdown.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/Dropdown.vue
@@ -9,7 +9,8 @@
       v-show="isopen" 
       ref="buttonsContainer" 
       :class="positionclass" 
-      class="buttons-container">
+      class="buttons-container"
+      @mouseleave="showDropdownComponent">
       <!-- TODO why we need IDs for them?? a class will not work? -->
       <div
         v-for="(button, index) in providersbutton"
@@ -80,7 +81,7 @@ export default {
   border: @defaultBorder;
   border-radius: 3px;
   margin-top: 3px;
-  min-width: @width + 30px;
+  min-width: @width;
   max-width: @width + @width;
   box-shadow: @defaultShadow;
   position: absolute;

--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/DropdownHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/DropdownHeader.vue
@@ -3,12 +3,21 @@
     :style="{ 'background-color': header.bgHover }"
     class="dropdown-header"
     @click="showdropdowncomponent(); passrefs()">
-    <div class="dropdown-heading px-2">
-       <i
-      :style="{ 'background-color': header.bgMini }"
-      :class="header.paddingClass"
-      class="uiIconMiniArrowDown uiIconLightGray pa-1"></i>
-      <i class="uiIconSocPhone uiIconSocBlue"></i>
+    <div class="dropdown-heading pe-2">
+      <i
+        :style="{ 'background-color': header.bgMini }"
+        :class="header.paddingClass"
+        class="uiIconMiniArrowDown uiIconLightGray pa-1"></i>
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on, attrs }">
+          <i 
+            v-bind="attrs"
+            v-on="on" 
+            class="uiIconSocPhone uiIconSocBlue v-btn--icon v-size--default d-flex align-center justify-content-center justify-center"></i>
+        </template>
+        <span>{{ $i18n.te("webconferencing.callHeader") ? $i18n.t("webconferencing.callHeader")
+          : "Start Call" }}</span>
+      </v-tooltip>
       <span v-if="!isMobile">
         {{ $i18n.te("webconferencing.callHeader") ? $i18n.t("webconferencing.callHeader")
           : "Start Call" }}</span>
@@ -51,7 +60,7 @@ export default {
     border-radius: 3px;
     width: 100%;
     min-height: 36px;
-    color: var(--allPagesDarkGrey, #4d5466) !important;
+    color: @primaryColor !important;
     letter-spacing: normal;
     .uiIconMiniArrowDown {
       color: var(--allPagesDarkGrey, #4d5466) !important;
@@ -86,8 +95,8 @@ export default {
     }
     .uiIconMiniArrowDown {
       position: absolute;
-      top: 7px;
-      right: -7px;
+      top: 9px;
+      right: 2px;
       text-align: center;
       &::before {
         color: @primaryColor;


### PR DESCRIPTION
Before this fix, when we activate webRTC, the user's popover window is badly displayed with the drawdown call options.
With this fix, we adjust the CSS style of the user popover when the webRTC option is enabled.