### PR TITLE
TASK-57415: Fix call icon on chat drawer's mask

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
@@ -323,8 +323,6 @@ export default {
       width: 100%;
     }
     cursor: pointer !important;
-    position: relative;
-    z-index: 100;
     min-height: 36px;
   }
   [class^="call-button-container-"]:hover,
@@ -405,6 +403,7 @@ export default {
     .buttons-container {
       top: 27px;
       right: -70px!important;
+      z-index: 100;
     }
   }
 }


### PR DESCRIPTION
ISSUES : In the chat drawer discussions, when we click on one of the collaborators' actions, the call icon is always clickable.
FIX : The problem was fixed by adjusting some CSS properties of call icon class so that it is not clickable in the case of an overlay.