### PR TITLE
fix: Unable to start a call in a new space - EXO-62598

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
@@ -327,7 +327,8 @@ public class RESTWebConferencingService implements ResourceContainer {
           Space space = spaceService.getSpaceByPrettyName(spaceName);
           if (space != null) {
             if (spaceService.isMember(space, currentUserName)) {
-              return Response.ok().cacheControl(cacheControl).entity(space).build();
+              WebConferencingService.SpaceInfo spaceInfo = webConferencing.new SpaceInfo((space));
+              return Response.ok().cacheControl(cacheControl).entity(spaceInfo).build();
             } else {
               return Response.status(Status.FORBIDDEN)
                              .cacheControl(cacheControl)


### PR DESCRIPTION
Before this fix, it is impossible to start a call in a new created space This problem is due to the fact that the returned object in the function getSpaceInfo is a Space object. This space Object have a type which is "team", "collaboration" ... in function of the template used to create it. But webconferencing need type "space" to be able to create call This fix create a SpaceInfo from the space and return it.