### PR TITLE
fix: Can't rename the call recording file - EXO-61701

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2218,7 +2218,16 @@ public class WebConferencingService implements Startable {
                                                           .append(PermissionType.ADD_NODE)
                                                           .append(",")
                                                           .append(PermissionType.SET_PROPERTY)
+                                                          .append(",")
+                                                          .append(PermissionType.REMOVE)
                                                           .toString();
+      try {
+        if (PermissionUtil.canChangePermission(fileNode)) {
+          setUserPermission(fileNode, user, perm.split(","));
+        }
+      } catch (Exception e) {
+        LOG.error("Cannot set user permission to file node.", e.getMessage());
+      }
       // Share file to other users
       if (shareToUsers != null) {
         for (String participant : shareToUsers) {
@@ -2342,6 +2351,10 @@ public class WebConferencingService implements Startable {
       String nodeMimeType = org.exoplatform.wcm.ext.component.activity.listener.Utils.getMimeType(recordNode);
       link.addMixin(NodetypeConstant.MIX_FILE_TYPE);
       link.setProperty(NodetypeConstant.EXO_FILE_TYPE, nodeMimeType);
+      if (!link.hasProperty(EXO_TITLE_PROP)) {
+        link.addMixin(EXO_RSS_ENABLE_PROP);
+      }
+      link.setProperty(EXO_TITLE_PROP, recordNode.getName());
       userPrivateNode.save();
     } catch (RepositoryException e) {
       if (LOG.isErrorEnabled()) {


### PR DESCRIPTION
Before this change, in user-to-user calls and when we save the call recording, we can't change the title of the downloaded recording for the owner and participants.After this change, we can rename the recording file,which is fixed by adding to the recording file node the remove permission in the case of the owner and the exo:title property in the case of participants.