### PR TITLE
fix: Preserve webconf_session_token cookie httponly and secure state for logout filter processing

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/server/filter/LogoutFilter.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/server/filter/LogoutFilter.java
@@ -35,6 +35,8 @@ public class LogoutFilter implements Filter {
       Cookie cookie = new Cookie(WebConferencingService.SESSION_TOKEN_COOKIE, "");
       cookie.setPath("/");
       cookie.setMaxAge(0);
+      cookie.setHttpOnly(true);
+      cookie.setSecure(request.isSecure());
       httpResponse.addCookie(cookie);
     }
     chain.doFilter(request, response);


### PR DESCRIPTION
Before this PR, during the logout process, the `webconf_session_token` cookie is recreated and configured to be invalidated and insecure  (the httponly and secure states are restored to the default ones). This change will ensure that the cookie remains secure even after its expiration.