### PR TITLE
fix: jitsi call button is not well displayed in left menu level 2 - EXO-66752

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
@@ -358,9 +358,7 @@ export default {
       }
       &.single {
         padding: 0;
-        width: unset;
         border: none;
-        height: 20px;
         background-color: transparent !important;
         // &.single-btn-container {
         button {
@@ -482,9 +480,6 @@ export default {
   margin-right: 6px;
   .call-button-container {
     padding: 0 10px 10px 0;
-    &.single {
-      padding: 0 10px 10px 0;
-    }
   }
 }
 .space-title-action-components {


### PR DESCRIPTION
Before this fix, the button is not aligned with other in left menu level 2 (on a space). In addition, when overring the button, the hover shadow is not displayed This fix modifies the vue component which display the jitsi button in order to respect the other button organization. In addition, css are updated to have the correct display everywhere the button is displayed (left menu level 2, space popover, chat drawer, chat application, in which we dont want the shadow)