### PR TITLE
fix: retrieve curent space without using Webui context - EXO-68991

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/Utils.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/Utils.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.text.ParseException;
 import java.util.*;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.utils.ISO8601;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
@@ -124,15 +125,31 @@ public class Utils {
    * @return the current context
    */
   public static ContextInfo getCurrentContext(String userId, Locale locale) {
-    String spaceRoomName;
-    String spacePrettyName = Utils.getSpaceNameByContext();
-    if (spacePrettyName != null) {
-      // TODO do we need a room name? what if chat room?
-      spaceRoomName = Utils.spaceRoomName(spacePrettyName);
-    } else {
-      spacePrettyName = spaceRoomName = IdentityInfo.EMPTY;
-    }
+    return getCurrentContext(userId, null, locale);
+  }
+
+  /**
+   * Gets the current context.
+   *
+   * @param userId the user id
+   * @param spaceId the current space id
+   * @param locale the locale
+   * @return the current context
+   */
+  public static ContextInfo getCurrentContext(String userId, String spaceId, Locale locale) {
+    String spaceRoomName = "";
+    String spacePrettyName = "";
     ExoContainer exo = ExoContainerContext.getCurrentContainer();
+    SpaceService spaceService = exo.getComponentInstanceOfType(SpaceService.class);
+    if(StringUtils.isNotBlank(spaceId)) {
+      Space space = spaceService.getSpaceById(spaceId);
+      if (space != null) {
+        spacePrettyName = space.getPrettyName();
+        spaceRoomName = Utils.spaceRoomName(spacePrettyName);
+      } else {
+        spacePrettyName = spaceRoomName = IdentityInfo.EMPTY;
+      }
+    }
     WebConferencingService webConferencing = exo.getComponentInstanceOfType(WebConferencingService.class);
     CometdWebConferencingService cometdService = exo.getComponentInstanceOfType(CometdWebConferencingService.class);
     ContextInfo context;

--- a/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
@@ -318,6 +318,7 @@ public class RESTWebConferencingService implements ResourceContainer {
      @ApiResponse(responseCode = "500", description = "Internal server error due to data encoding or formatting result to JSON. Error code: " + ErrorInfo.CODE_SERVER_ERROR)})
   public Response getContext(@Context UriInfo uriInfo,
                               @Parameter(description = "User name", required = true) @QueryParam("name") String userName,
+                              @Parameter(description = "Space Id", required = true) @QueryParam("spaceId") String spaceId,
                               @Parameter(description = "Language", required = true) @QueryParam("lang") String language) {
     Locale currentLocale = localeConfigService.getDefaultLocaleConfig().getLocale();
     if(StringUtils.isBlank(userName)) {
@@ -333,7 +334,7 @@ public class RESTWebConferencingService implements ResourceContainer {
     if (convo != null) {
       String currentUserName = convo.getIdentity().getUserId();
       if (StringUtils.isNotBlank(userName) && userName.equals(currentUserName)) {
-        ContextInfo context = Utils.getCurrentContext(userName, currentLocale);
+        ContextInfo context = Utils.getCurrentContext(userName, spaceId, currentLocale);
         try {
           return Response.ok().cacheControl(cacheControl).entity(Utils.asJSON(context)).build();
         } catch (JsonException jsonException) {

--- a/webapp/src/main/webapp/js/webconferencing.js
+++ b/webapp/src/main/webapp/js/webconferencing.js
@@ -2010,7 +2010,7 @@
       });
     },
       this.loadContext = function (userName, language) {
-        return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/webconferencing/context?name=${userName}&lang=${language}`, {
+        return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/webconferencing/context?name=${userName}&spaceId=${eXo.env.portal.spaceId ? eXo.env.portal.spaceId : ''}&lang=${language}`, {
           credentials: 'include',
           method: 'GET',
         }).then(resp => {


### PR DESCRIPTION
To load the current context, the webconferencing Rest service uses the web controller which does not provide the needed information in all cases. The fix will provide the space id when the page is a space page directly to the Rest service.