### PR TITLE
fix: display of call button in mobile device - EXO-67690 - Meeds-io/meeds#1586 .

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing-call-plugin.js
+++ b/webapp/src/main/webapp/js/webconferencing-call-plugin.js
@@ -245,6 +245,7 @@
       iconName: "callButton",
       appClass: CALL_BUTTON,
       typeClass: "call-button--profile",
+      mobileClass: "call-button-mini",
       component: {
         name: "call-button",
         events: [],


### PR DESCRIPTION
Before this change, when using mobile device, open the profile of a user, The call button is displayed as a button with call text. After this change, The call button is displayed only the icon, without the border and without the text.