### PR TITLE
fix: Remove webrtc option - EXO-68229

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButtons/main.js
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/main.js
@@ -70,6 +70,8 @@ export function create(context, target) {
             });
           }
         });
+      }).finally(() => {
+        Vue.prototype.$utils.includeExtensions('VisioConnector');
       });
     } else {
       const log = webConferencing.getLog('webconferencing');


### PR DESCRIPTION
Before this fix, when the addon external-visio-connector is installed, the connector initialization fails, and so call button are not displayed, even if external visio connector is not active This is due to the fact that external-visio-connector javascript module is not loaded correctly This commit add the line finally.includeExtension on the vue component CallButton so that the connector is correctly loaded and can initialize