### PR TITLE
feat: Adjusted behavior of integrated video conference switch button - EXO-69807

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -4011,9 +4011,10 @@ public class WebConferencingService implements Startable {
   public List<ActiveCallProvider> getActiveProvidersForSpace(String spaceId) {
     List<ActiveCallProvider> allProviders = new ArrayList<>();
     for (CallProvider registeredProvider : providers.values()) {
-      allProviders.addAll(registeredProvider.getActiveProvidersForSpace(spaceId));
+      if(getProvider(registeredProvider.getType()).isActive()) {
+        allProviders.addAll(registeredProvider.getActiveProvidersForSpace(spaceId));
+      }
     }
-
     return allProviders.stream().map(provider -> updateCallProviderUrl(spaceId, provider)).toList();
   }
 


### PR DESCRIPTION
Prior to this change, all inactive integrated video conferences were displayed in the list of video conferences within space settings, and the switch button for integrated video conferencing did not function correctly. After this change, we've implemented a verification to ensure that only active integrated video conferences are displayed in the list within space settings.