### PR TITLE
fix: some events in webconferencing are not correctly configured - EXO-70693

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/cometd/CometdWebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/cometd/CometdWebConferencingService.java
@@ -45,9 +45,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.inject.Inject;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
 
 import static org.exoplatform.webconferencing.Utils.asJSON;
 import static org.exoplatform.webconferencing.Utils.parseISODate;


### PR DESCRIPTION
Before this fix, event like callJoined, callStopped ... are not seen in front side This is due to some listener not correctly added when CometWebConferencingservice starts : This listeners are added in postConstruct method, which is no more call, because the used annotation is the old javax.annotation.PostConstruct.

This commit update the annotion to use jakarta.annotation.PostConstruct. It also change PreDestroy and Inject annotations