### PR TITLE
fix: call button are not displayed when user is not administrator - EXO-70783

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
@@ -214,7 +214,7 @@ public class RESTWebConferencingService implements ResourceContainer {
    * @return the provider configs
    */
   @GET
-  @RolesAllowed("administrators")
+  @RolesAllowed("users")
   @Path("/providers/configuration")
   @Operation(
           summary = "Read call providers configurations",


### PR DESCRIPTION
Before this fix, the call button is not dsiplayed because the rest service to get call provider configuration is limited to administrators 
This commit open the service to users.