### PR TITLE
fix: call button are not displayed when user is not administrator - EXO-70783

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing.js
+++ b/webapp/src/main/webapp/js/webconferencing.js
@@ -979,7 +979,7 @@
           var isRoom = target.detail.type === "t"; // roomId && roomId.startsWith("team-");
           var isGroup = isSpace || isRoom;
           // roomName from its title - it is a logic used in Chat, so reuse it here:
-          var roomName = roomTitle.toLowerCase().split(" ").join("_");
+          var roomName = target.detail.prettyName;
           context = {
             currentUser: currentUser,
             roomId: target.detail.user,


### PR DESCRIPTION
Before this fix, the call button is not dsiplayed because the rest service to get call provider configuration is limited to administrators This commit open the service to users.
In addition, when the space pretty name contains hyphen (-), the call  button is not displayed.
This commit change the calculation of room name by using directly the pretty name instead of trying to recalculate it.