### PR TITLE
fix: Split crowdin label in two strings - EXo-70174

### DIFF
--- a/services/src/main/resources/locale/webconferencing/WebConferencingAdmin_en.xml
+++ b/services/src/main/resources/locale/webconferencing/WebConferencingAdmin_en.xml
@@ -41,7 +41,12 @@
         <description>Jitsi provider for WebConferencing</description>
       </Jitsi>
       <switch>
-        <label>Enable/Disable {0} video conference</label>
+        <disable>
+          <label>Disable {0} video conference</label>
+        </disable>
+        <enable>
+          <label>Enable {0} video conference</label>
+        </enable>
       </switch>
       <modal>
         <title>Provider settings</title>

--- a/services/src/main/resources/locale/webconferencing/WebConferencingAdmin_fr.xml
+++ b/services/src/main/resources/locale/webconferencing/WebConferencingAdmin_fr.xml
@@ -43,6 +43,15 @@
       <switch>
         <label>Enable/Disable {0} video conference</label>
       </switch>
+
+      <switch>
+        <disable>
+          <label>Désactiver la video conference {0}</label>
+        </disable>
+        <enable>
+          <label>Activer la video conference {0}</label>
+        </enable>
+      </switch>
       <modal>
         <title>Paramètres du fournisseur</title>
         <SearchLabel>URL :</SearchLabel>

--- a/webapp/src/main/webapp/vue-apps/Admin/components/AdminApp.vue
+++ b/webapp/src/main/webapp/vue-apps/Admin/components/AdminApp.vue
@@ -27,7 +27,7 @@
           <v-switch
             :input-value="providerConfig.active"
             v-model="providerConfig.active"
-            :aria-label="$t('webconferencing.admin.switch.label', {0:providerConfig.title})"
+            :aria-label="providerConfig.active ? $t('webconferencing.admin.switch.disable.label', {0:providerConfig.title}) : $t('webconferencing.admin.switch.enable.label', {0:providerConfig.title})"
             color="primary"
             class="providersSwitcher"
             @change="changeActive(providerConfig)" />


### PR DESCRIPTION
Before this fix, the aria label for activating/deactivating a visio was the same, no matter the status This modification introduces 2 differents labels, used in function of the current switch state.