### PR TITLE
fix: fix margin in visio admin app - EXO-70955

### DIFF
--- a/webapp/src/main/webapp/vue-apps/Admin/components/AdminApp.vue
+++ b/webapp/src/main/webapp/vue-apps/Admin/components/AdminApp.vue
@@ -36,7 +36,7 @@
           <v-list-item-title class="subtitle-1 pt-2">
             {{ $t(`webconferencing.admin.${providerConfig.title}.name`)
               ? $t(`webconferencing.admin.${providerConfig.title}.name`)
-              : providerConfig.title }} 
+              : providerConfig.title }}
           </v-list-item-title>
           <v-list-item-subtitle>
             {{ $t(`webconferencing.admin.${providerConfig.title}.description`)
@@ -45,13 +45,15 @@
           </v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>
-      <div  
-        v-for="extension in additionalVisioExtensions"
-        :key="extension">
-        <extension-registry-components
-          name="additional-visio-actions"
-          :type="extension.componentName" />
-      </div>
+      <v-list-item class="px-0">
+        <div
+          v-for="extension in additionalVisioExtensions"
+          :key="extension">
+          <extension-registry-components
+            name="additional-visio-actions"
+            :type="extension.componentName" />
+        </div>
+      </v-list-item>
     </v-card>
   </v-app>
 </template>


### PR DESCRIPTION
Before this fix, when external visio is not activated, there is no bottom margin This commit put the extension in a v-list-item, so that a margin is kept when there is no extension to display