### PR TITLE
fix: Call button on user card is not correctly displayed - EXO-71512

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/DropdownHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/DropdownHeader.vue
@@ -4,7 +4,7 @@
     class="dropdown-header">
     <div
       class="dropdown-heading d-flex d-row align-center justify-center ps-2"
-      @click="startCall()">
+      @click.stop.prevent="startCall()">
       <v-tooltip bottom>
         <template v-slot:activator="{ on, attrs }">
           <v-icon


### PR DESCRIPTION
Before this fix, the call button on user card was not correctly displayed :
- in mobile view, the button was not displayed
- when there are more than one provider, the display was not correct

This fix address both problem by reworking the extension