### PR TITLE
fix: Call button on user card is not correctly displayed - EXO-71512

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing-call-plugin.js
+++ b/webapp/src/main/webapp/js/webconferencing-call-plugin.js
@@ -129,8 +129,9 @@
       },
 
       // enabled just show that this extension is enabled, if enabled: false WebConferencingCallComponent will not appear on page
-      enabled: function() {
-        return true;
+      enabled: function(element) {
+        //return true only if the extension is used for a user card. We dont want it on a space card for the moment
+        return element?.username;
       }
     },
     {


### PR DESCRIPTION
Before this fix, the call button on user card was not correctly displayed :
- in mobile view, the button was not displayed
- when there are more than one provider, the display was not correct

This fix address both problem by reworking the extension