### PR TITLE
fix: Jitsi call can't be launched when room name is too long - eXo-71657

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2876,6 +2876,7 @@ public class WebConferencingService implements Startable {
    */
   private String createInvite(String callId) {
     String inviteId = codec.encode(callId);
+    inviteId = inviteId.substring(0,32);
     byte[] inviteIdBytes = Base64.getDecoder().decode(inviteId);
     inviteId = Base64.getUrlEncoder().withoutPadding().encodeToString(inviteIdBytes);
 


### PR DESCRIPTION
Before this fix, when we call codec.encode(callId), the sub class use org.gatein.common.util.Base64 to encode callId. A base64 have a length limit, and this function add '\n' char when the limit it reach to separate lines. The java.util.Base64 does not recognise this character and throw an error.

First option was to simply remove the \n in inviteId after encode, but the invite id generated is larger than 32char, the limit of the field in database As it is not necessary to have long inviteId value, and as the risk of collide is very low with the first 32 chars, this fix limit the length of the invite. With that, the \n char is certainly removed (as it occurs after the 32nd char), AND the inviteId is not too long for the column in database.