### PR TITLE
fix: When editing an event, visio conference button is "create a visio" - EXO-72138

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2876,7 +2876,9 @@ public class WebConferencingService implements Startable {
    */
   private String createInvite(String callId) {
     String inviteId = codec.encode(callId);
-    inviteId = inviteId.substring(0,32);
+    if (inviteId.length()>32) {
+      inviteId = inviteId.substring(0, 32);
+    }
     byte[] inviteIdBytes = Base64.getDecoder().decode(inviteId);
     inviteId = Base64.getUrlEncoder().withoutPadding().encodeToString(inviteIdBytes);
 


### PR DESCRIPTION
Before this fix, when creating a visio for an event different from jitsi, there was an error in server log. This error comes from the substring when creating the inviteId, for other visio than jitsi, the callId is less longer than 32 chars, so the substring generates and error This commit add a test to not make the substring if not necessary