### PR TITLE
fix: Agenda : if external visio have a long url, unable to store the event

### DIFF
--- a/webapp/src/main/resources/locale/portlet/videoConference/VideoConference_en.properties
+++ b/webapp/src/main/resources/locale/portlet/videoConference/VideoConference_en.properties
@@ -35,6 +35,7 @@ videoConference.drawer.link.description=Paste the link provided by your video co
 videoConference.drawer.link.placeholder=Enter the URL of the video conference
 videoConference.label.saveLink.success=Video conference sets successfully
 videoConference.label.invalidLink=Invalid link
+videoConference.label.tooLongLink=The URL cannot be longer than 500 chars
 videoConference.required.error.message=This field is required
 videoConference.label.btn.cancel=Cancel
 videoConference.label.btn.Save=Save

--- a/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/components/VideoConferenceLinkDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/components/VideoConferenceLinkDrawer.vue
@@ -83,7 +83,7 @@ export default {
       videoConferenceLink: '',
       isValidForm: true,
       linkRules: [url => !url || url.length === 0 || !!(url.match(/^((https?:\/\/)?(www\.)?[a-zA-Z0-9]+\.[^\s]{2,})|(javascript:)|(\/portal\/)/))
-              || this.$t('videoConference.label.invalidLink')],
+              || this.$t('videoConference.label.invalidLink'), url => !url || url.length <= 500 || this.$t('videoConference.label.tooLongLink')],
     };
   },
   created() {

--- a/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/components/VideoConferenceLinkDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/components/VideoConferenceLinkDrawer.vue
@@ -49,6 +49,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               v-model="videoConferenceLink"
               :placeholder="$t('videoConference.drawer.link.placeholder')"
               :rules="linkRules"
+              @input="checkUpdate"
+              clearable
               class="pt-0"
               type="text"
               outlined
@@ -81,7 +83,7 @@ export default {
       spaceId: eXo.env.portal.spaceId,
       videoConference: null,
       videoConferenceLink: '',
-      isValidForm: true,
+      isValidForm: false,
       linkRules: [url => !url || url.length === 0 || !!(url.match(/^((https?:\/\/)?(www\.)?[a-zA-Z0-9]+\.[^\s]{2,})|(javascript:)|(\/portal\/)/))
               || this.$t('videoConference.label.invalidLink'), url => !url || url.length <= 500 || this.$t('videoConference.label.tooLongLink')],
     };
@@ -108,7 +110,6 @@ export default {
       });
     },
     close() {
-      this.isValidForm = false;
       this.videoConferenceLink = '';
       this.videoConference = null;
       this.$nextTick().then(() => this.$refs.videoConferenceLinkDrawer.close());
@@ -129,5 +130,6 @@ export default {
       });
     }
   }
+
 };
 </script>


### PR DESCRIPTION
Before this fix, if the visio url is longer than 500 char, and when it is used for a space event, the visio link was not savec because the filed in db is limited to 500chars This commit add a check when filling the space meeting url, to not add a link longer than 500 chars