### PR TITLE
fix: [BUG] - conferencing - can't manipulate recordings(  space/personal ) in default folder documents - EXO-71918 (#323)

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2205,11 +2205,16 @@ public class WebConferencingService implements Startable {
       LOG.error("Cannot set conversation state for user: " + user, e);
       throw new UploadFileException("Cannot set conversation state for user: " + user);
     }
-
     ManageableRepository repository = repositoryService.getCurrentRepository();
-    SessionProvider systemSessionProvider = sessionProviders.getSystemSessionProvider(null);
-    Session session = systemSessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
-    // Get node under system session
+    SessionProvider sessionProvider = sessionProviders.getSessionProvider(state);
+    sessionProviders.setSessionProvider(null, sessionProvider);
+    if (parent.getPath().contains("Groups/spaces")) {
+      Space space = spaceService.getSpaceByGroupId(parent.getPath().split("/Groups")[1].split("/Documents")[0]);
+      if (space == null || !spaceService.isMember(space, user)) { // If user is not member of the space we use system session
+        sessionProvider = sessionProviders.getSystemSessionProvider(null);
+      }
+    }
+    Session session = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
     Node folder = (Node) session.getItem(parent.getPath());
     Node recordingsFolder = getRecordingsFolder(folder);
 


### PR DESCRIPTION
Prior to this change, all recording created for calls are created bu system, so users can't manipulate them, this fix use the user session to create the records