### PR TITLE
fix: do not recreate inivitation if it is already existent - EXO-73838

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -3054,10 +3054,9 @@ public class WebConferencingService implements Startable {
     if (getProvider(call.providerType).canInvite()) {
       // Check if invitation for this call exist
       List<InviteEntity> invites = inviteStorage.findCallInvites(callId);
-      if (!invites.isEmpty()) {
-        inviteStorage.deleteCallInvites(callId);
+      if (invites.isEmpty()) {
+        call.setInviteId(createInvite(callId));
       }
-      call.setInviteId(createInvite(callId));
     }
     if (LOG.isDebugEnabled()) {
       LOG.debug("<< txCreateCall: " + call.getId());


### PR DESCRIPTION
If the invitation is already created, we simply do not recreate it.
This fix may be temporary until changing how invitation are generated and should be changed over time to secure Call invitation links. 