### PR TITLE
fix: Do not create invitation if it is already created for a call - EXO-73838

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -3052,7 +3052,11 @@ public class WebConferencingService implements Startable {
       originsStorage.create(createOriginEntity(callId, o));
     }
     if (getProvider(call.providerType).canInvite()) {
-      call.setInviteId(createInvite(callId));
+      // Check if invitation for this call exist
+      List<InviteEntity> invites = inviteStorage.findCallInvites(callId);
+      if (invites.isEmpty()) {
+        call.setInviteId(createInvite(callId));
+      }
     }
     if (LOG.isDebugEnabled()) {
       LOG.debug("<< txCreateCall: " + call.getId());

--- a/services/src/main/java/org/exoplatform/webconferencing/dao/InviteDAO.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/dao/InviteDAO.java
@@ -47,7 +47,6 @@ public class InviteDAO extends GenericDAOJPAImpl<InviteEntity, InviteId> {
    * @throws IllegalStateException the illegal state exception
    * @throws IllegalArgumentException the illegal argument exception
    */
-  @Deprecated // TODO not used
   public int deleteCallInvites(String callId) throws PersistenceException, IllegalStateException, IllegalArgumentException {
     return getEntityManager().createNamedQuery("WebConfInvite.deleteCallInvites").setParameter("callId", callId).executeUpdate();
   }


### PR DESCRIPTION
In some cases, the call invites is not removed when the call ends. Thus when trying to start the call again, the call could not be recreated as the invite is still available inside the INVITES table. The fix will check the invites and avoid recreating new invites when the call is recreated.