### PR TITLE
fix: Empty action on the 3 dots of a user when videoconferencing deactivated - EXO-76187.

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing-call-plugin.js
+++ b/webapp/src/main/webapp/js/webconferencing-call-plugin.js
@@ -131,7 +131,7 @@
       // enabled just show that this extension is enabled, if enabled: false WebConferencingCallComponent will not appear on page
       enabled: function(element) {
         //return true only if the extension is used for a user card. We dont want it on a space card for the moment
-        return element?.username && element?.username !== eXo.env.portal.userName;
+        return element?.username && element?.username !== eXo.env.portal.userName && eXo.webConferencing.jitsi.isInitialized;
       }
     },
     {


### PR DESCRIPTION
Before this change, when deactivate Jitsi and external videoconference in the administration and check on any field which is group synchronized then click on the 3 dots of a user in the results, empty place where I'm should have the videoconference option. To resolve this problem, add a check condition if Jitsi is initialized in the  extension. After this change, if jitsi is disabled menu action is only display the available options without empty space.