### PR TITLE
fix: Profile header is displayed over sidebar - EXO-77147

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
@@ -532,11 +532,6 @@ export default {
   }
 }
 
-#UIProfileHeaderContainer {
-  position: relative;
-  z-index: 100;
-}
-
 #identity-popover {
   .call-button-popover--profile {
     button {


### PR DESCRIPTION
Beofre this fix, the profile header is displayed over sidebar due to old and unnecessary z-index property

This commit removes the unused css rule