### PR TITLE
fix : webconferencing can be deactivated by a space member - EXO-77553

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/rest/RESTWebConferencingService.java
@@ -715,7 +715,7 @@ public class RESTWebConferencingService implements ResourceContainer {
 
     String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
     Space space = spaceService.getSpaceById(spaceId);
-    if (space == null || (!spaceService.isMember(space, authenticatedUser) && !spaceService.isSuperManager(authenticatedUser))) {
+    if (space == null || (!spaceService.isManager(space, authenticatedUser) && !spaceService.isSuperManager(authenticatedUser))) {
       return Response.status(Response.Status.UNAUTHORIZED).build();
     }
     try {

--- a/webapp/src/main/resources/locale/portlet/videoConference/VideoConference_en.properties
+++ b/webapp/src/main/resources/locale/portlet/videoConference/VideoConference_en.properties
@@ -39,3 +39,5 @@ videoConference.label.tooLongLink=The URL cannot be longer than 500 chars
 videoConference.required.error.message=This field is required
 videoConference.label.btn.cancel=Cancel
 videoConference.label.btn.Save=Save
+videoConference.error.unknownErrorWhenSavingSpace=An unknown error happened when saving the configuration. Please contact the support services.
+

--- a/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/components/SpaceVideoConferenceSetting.vue
+++ b/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/components/SpaceVideoConferenceSetting.vue
@@ -33,6 +33,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <v-list-item-action class="pt-6">
             <v-switch
               v-model="active"
+              @change="updateVideoConferenceEnabled(active, undefined)"
               :aria-label="this.$t(`videoConference.switch.label.${this.switchAriaLabel}`)" />
           </v-list-item-action>
         </v-list-item>
@@ -112,11 +113,6 @@ export default {
       return this.activeProviders.some((provider) => !provider.integratedConnector ) || this.activeProviders.filter((provider) => provider.integratedConnector ).length > 1;
     },
   },
-  watch: {
-    active() {
-      this.updateVideoConferenceEnabled(this.active);
-    }
-  },
   methods: {
     getActiveProvidersForSpace() {
       this.$videoConferenceService.getActiveProvidersForSpace(this.spaceId)
@@ -128,7 +124,12 @@ export default {
         });
     },
     updateVideoConferenceEnabled(enabled, provider) {
-      this.$videoConferenceService.updateVideoConferenceEnabled(this.spaceId, enabled,provider);
+      this.$videoConferenceService.updateVideoConferenceEnabled(this.spaceId, enabled,provider).then(() => {
+        this.active=enabled;
+      }).catch(() => {
+        this.active=!enabled;
+        this.$root.$emit('alert-message', this.$t('videoConference.error.unknownErrorWhenSavingSpace'), 'error');
+      });
     },
     isVideoConferenceEnabled() {
       this.$videoConferenceService.isVideoConferenceEnabled(this.spaceId)


### PR DESCRIPTION
Before this fix, a space member can deactivate webconf for a space without having space manager rights This commit change the API check, and add an error message on front side if the user is not authorized to make the change