### PR TITLE
fix : People directory do not load if jisti addon is uninstalled - EXO-79467

### DIFF
--- a/webapp/src/main/webapp/js/webconferencing-call-plugin.js
+++ b/webapp/src/main/webapp/js/webconferencing-call-plugin.js
@@ -156,7 +156,7 @@
       // enabled just show that this extension is enabled, if enabled: false WebConferencingCallComponent will not appear on page
       enabled: function(element) {
         //return true only if the extension is used for a user card. We dont want it on a space card for the moment
-        return element?.username && element?.username !== eXo.env.portal.userName && eXo.webConferencing.jitsi.isInitialized;
+        return element?.username && element?.username !== eXo.env.portal.userName && eXo?.webConferencing?.jitsi?.isInitialized;
       }
     },
     {


### PR DESCRIPTION
Before this fix, when peopl page load, it search profile-extension, and the one for webconferencing try to load object eXo.webconferencing which not exists, and generate a undefined exception This fix test the existence of the object before using it.