### PR TITLE
fix: prevent space settings extension registration when no active providers - EXO-83712

### DIFF
--- a/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/VideoConferenceService.js
+++ b/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/VideoConferenceService.js
@@ -59,4 +59,24 @@ export function isVideoConferenceEnabled(spaceId) {
   });
 }
 
+export async function hasActiveProviders() {
+  try {
+    const response = await fetch(
+      `${eXo.env.portal.context}/${eXo.env.portal.rest}/webconferencing/providers/configuration`,
+      {
+        method: 'GET',
+        credentials: 'include',
+      }
+    );
+
+    if (!response.ok) {
+      return false;
+    }
+    const settings = await response.json();
+    return Array.isArray(settings) && settings.some(provider => provider.active === true);
+
+  } catch (e) {
+    return false;
+  }
+}
 

--- a/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/main.js
+++ b/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/main.js
@@ -15,6 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import './initComponents.js';
+import { hasActiveProviders } from './VideoConferenceService.js';
 
 const lang = eXo && eXo.env.portal.language || 'en';
 
@@ -23,10 +24,19 @@ const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale
 
 exoi18n.loadLanguageAsync(lang, url);
 
-if (extensionRegistry) {
-  extensionRegistry.registerComponent('SpaceSettings', 'space-settings-components', {
-    id: 'video-conference-space-setting',
-    vueComponent: Vue.options.components['space-video-conference-settings'],
-    rank: 15,
-  });
-}
+(async () => {
+  const hasProviders = await hasActiveProviders();
+
+  if (extensionRegistry && hasProviders) {
+    extensionRegistry.registerComponent(
+      'SpaceSettings',
+      'space-settings-components',
+      {
+        id: 'video-conference-space-setting',
+        vueComponent:
+          Vue.options.components['space-video-conference-settings'],
+        rank: 15,
+      }
+    );
+  }
+})();


### PR DESCRIPTION
Prior to this change, the web conferencing space settings extension component was loaded in Space Settings even when all providers were disabled. This resulted in showing configuration options that should not be available.

The provider configuration is now checked before registering the extension. The space settings extension is registered only if there is at least one provider is explicitly marked as active.