### PR TITLE
fix : Add margin for call buttons - EXO-85837

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/Dropdown.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/Dropdown.vue
@@ -16,7 +16,7 @@
       <div
         v-for="(button, index) in providersbutton"
         :key="index"
-        :class="`call-button-container-${index}`"
+        :class="`call-button-container-${index} me-2`"
         :ref="`callbutton`"
         @click="selectProvider"></div>
     </div>


### PR DESCRIPTION
Before this fix, when the call button name is too long, there is no right margin. This commit add it