### PR TITLE
fix: Users card options alignment issue - EXO-80968

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
@@ -288,6 +288,9 @@ export default {
 @import "../../../skin/less/variables.less";
 @import "../../../skin/less/mixins.less";
 .VuetifyApp {
+  .v-list-item.call-button:hover{
+    background-color: var(--allPagesPrimaryBackground, #f0f0f0) !important;
+  }
   .call-button-container {
     min-width: 64px;
     max-width: 240px;
@@ -300,10 +303,7 @@ export default {
     &.single {
       // width: @width - 14px;
       height: 36px;
-      border: 1px solid rgb(232, 238, 242);
       border-radius: 3px;
-      background-color: var(--allPagesBaseBackground, #ffffff) !important;;
-      padding: 0 10px;
       .single-btn-container {
         height: inherit;
         a {
@@ -314,6 +314,9 @@ export default {
           [class^="uiIcon"] {
             &::before {
               vertical-align: super;
+            }
+            &:hover{
+              background-color: unset;
             }
           }
         }

--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/DropdownHeader.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/DropdownHeader.vue
@@ -9,7 +9,7 @@
         <template v-slot:activator="{ on, attrs }">
           <v-icon
             class="align-center d-flex"
-            size="20"
+            :size="isMenu ? '18' : '20'"
             v-bind="attrs"
             v-on="on">
             fas fa-video
@@ -20,7 +20,7 @@
       </v-tooltip>
       <span 
         v-if="!isMobile" 
-        :class="isMenu ? 'ms-3' : 'ps-2'"
+        :class="isMenu ? 'ms-4' : 'ps-2'"
         class="text-color">
         {{ $t("webconferencing.callHeader") ? $i18n.t("webconferencing.callHeader")
           : "Start Call" }}</span>
@@ -31,7 +31,9 @@
       dark  
       inset
       vertical />
-    <div class="px-1" @click.stop.prevent="showdropdowncomponent(); passrefs()">
+    <div 
+      :class="isMenu ? 'ps-3' : 'px-1'"
+      @click.stop.prevent="showdropdowncomponent(); passrefs()">
       <v-icon
         size="18"
         class="pb-1">
@@ -83,7 +85,7 @@ export default {
   .dropdown-header {
     display: inline-flex;
     align-items: center;
-    background-color: white;
+    background-color: unset;
     width: 100%;
     min-height: 36px;
     color: @primaryColor !important;


### PR DESCRIPTION
Before this change, when using the Unified Search user results view, opening the options menu on a user card could cause the video call icon and label to become misaligned when multiple external video conferencing providers were available and configured by the user. As a result, the display was not rendered as expected. To fix this problem, the dropdown component was replaced with v-menu. After this change, the video call icon and label are properly aligned, and the list of available video conferencing options is displayed correctly.