### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/listener/analytics/WebConferencingListener.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/listener/analytics/WebConferencingListener.java
@@ -116,22 +116,22 @@ public class WebConferencingListener extends Listener<CallInfo, Map<? extends St
                                              .filter(participant -> StringUtils.equals(UserState.JOINED, participant.getState()))
                                              .count();
 
-    statisticData.addParameter("participantsCount", participantsCount);
-    statisticData.addParameter("activeParticipantsCount", activeParticipantsCount);
-    statisticData.addParameter("callId", callInfo.getId());
-    statisticData.addParameter("callType", callType);
-    statisticData.addParameter("callOwnerType", callInfo.getOwner().getType());
-    statisticData.addParameter("callStartDate", callInfo.getStartDate());
-    statisticData.addParameter("callEndDate", callInfo.getEndDate());
-    statisticData.addParameter("callState", callInfo.getState());
+    statisticData.addLong("participantsCount", participantsCount);
+    statisticData.addLong("activeParticipantsCount", activeParticipantsCount);
+    statisticData.addKeyword("callId", callInfo.getId());
+    statisticData.addKeyword("callType", callType);
+    statisticData.addKeyword("callOwnerType", callInfo.getOwner().getType());
+    statisticData.addDate("callStartDate", callInfo.getStartDate());
+    statisticData.addDate("callEndDate", callInfo.getEndDate());
+    statisticData.addKeyword("callState", callInfo.getState());
     if (callDuration > 0) {
-      statisticData.addParameter("callDuration", callDuration);
+      statisticData.addLong("callDuration", callDuration);
     }
     if (info.get("status") != null) {
       statisticData.setStatus(info.get("status").equals(WebConferencingService.STATUS_OK) ? StatisticData.StatisticStatus.OK : StatisticData.StatisticStatus.KO);
     }
     if(info.containsKey("file_size")) {
-      statisticData.addParameter("recordedFileSizeInMB", info.get("file_size"));
+      statisticData.addDouble("recordedFileSizeInMB", info.get("file_size"));
     }
     addStatisticData(statisticData);
   }


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.