### PR TITLE
 fix: Icons alignment in chat - EXO-86926

### DIFF
--- a/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
+++ b/webapp/src/main/webapp/vue-apps/CallButtons/components/CallButtons.vue
@@ -517,9 +517,6 @@ export default {
 }
 .call-button-mini.call-button--chat-drawer {
   margin-right: 6px;
-  .call-button-container {
-    padding: 0 10px 10px 0;
-  }
 }
 .space-title-action-components {
   .call-button.call-button--space {


### PR DESCRIPTION
Before this change, when admin add external visio then userA fills app al of his external visio and userB displays userA in chat drawer, icons alignment isn't ok. To fix this, remove the padding added on the  class. After this change, alignment is preserved.