### PR TITLE
fix: video conference url not accepted in space settings - EXO-87828

### DIFF
--- a/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/components/VideoConferenceLinkDrawer.vue
+++ b/webapp/src/main/webapp/vue-apps/SpaceAdministrationVisioConference/components/VideoConferenceLinkDrawer.vue
@@ -84,7 +84,7 @@ export default {
       videoConference: null,
       videoConferenceLink: '',
       isValidForm: false,
-      linkRules: [url => !url || url.length === 0 || !!(url.match(/^((https?:\/\/)?(www\.)?[a-zA-Z0-9]+\.[^\s]{2,})|(javascript:)|(\/portal\/)/))
+      linkRules: [url => !url || url.length === 0 || !!(url.match(/^((https?:\/\/)?(www\.)?[a-zA-Z0-9]+[a-zA-Z0-9_-]*\.[^\s]{2,})|(javascript:)|(\/portal\/)/))
               || this.$t('videoConference.label.invalidLink'), url => !url || url.length <= 500 || this.$t('videoConference.label.tooLongLink')],
     };
   },


### PR DESCRIPTION
Before this change, when go to settings of space then click on edit icon of Video conference and add link which contain `_` or `-` in domain part of url, invalid link error message. To fix this, inserted [a-zA-Z0-9_-]* just before the \.and this allows you to accept a sequence of characters containing hyphens (-) or underscores (_) just before the period of the domain name. After this change, chars `_` and `-` is acceptable so no error is displayed.