### PR TITLE
feat: badge the eXo icon while a visio you belong to is going on EXO-89428

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -85,6 +85,12 @@
       <groupId>io.meeds.pwa</groupId>
       <artifactId>pwa-service</artifactId>
     </dependency>
+    <!-- App Center badge SPI (used to publish the ongoing-visios counter) -->
+    <dependency>
+      <groupId>io.meeds.app-center</groupId>
+      <artifactId>app-center-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/services/src/main/java/org/exoplatform/webconferencing/listener/VisioApplicationBadgeListener.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/listener/VisioApplicationBadgeListener.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.webconferencing.listener;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.webconferencing.CallInfo;
+import org.exoplatform.webconferencing.CallState;
+import org.exoplatform.webconferencing.UserInfo;
+import org.exoplatform.webconferencing.WebConferencingService;
+import org.exoplatform.webconferencing.plugin.VisioApplicationBadgePlugin;
+
+import io.meeds.appcenter.plugin.ApplicationBadgePlugin;
+import io.meeds.appcenter.service.ApplicationBadgeService;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Refreshes the Visio badge of every participant of a call that just started or
+ * just stopped.
+ * <p>
+ * Pure glue: it holds no counting logic, it only tells the Application Center
+ * that those users' counts went stale. This is what makes the badge real-time —
+ * a colleague starting the space visio makes the icon light up without anyone
+ * reloading a page.
+ * <p>
+ * The three event names below are the complete set of broadcasts that change
+ * whether a call is live:
+ * <ul>
+ * <li>{@code callStarted} and {@code callStopped} are the obvious ones;</li>
+ * <li>{@code callCreated} is the one that is easy to miss — a call created
+ * already running (the space call button, and any client calling {@code addCall}
+ * with {@code start=true}) is persisted in state {@code started} and broadcasts
+ * <strong>only</strong> {@code callCreated}, never {@code callStarted}. Without
+ * it the most common way a visio begins would raise no badge at all.</li>
+ * </ul>
+ * {@code callJoined} and {@code callLeft} are deliberately <em>not</em>
+ * listened to: with the plugin's "every started call" semantics the count does
+ * not move when somebody joins or leaves, so subscribing would evict and push
+ * to every participant of every call on every join, for no change.
+ * <p>
+ * Two paths change a call's liveness without broadcasting anything, and both
+ * are left to the badge cache's own expiry rather than papered over here:
+ * an outdated {@code started} call silently deleted while a replacement is
+ * created, and the reset of lingering {@code started} calls at server start —
+ * where the cache is empty anyway.
+ */
+@Component
+@Asynchronous
+@ConditionalOnClass(ApplicationBadgePlugin.class)
+public class VisioApplicationBadgeListener extends Listener<CallInfo, Map<String, String>> {
+
+  /** Logger of this listener. */
+  private static final Log          LOG         = ExoLogger.getLogger(VisioApplicationBadgeListener.class);
+
+  /** The complete set of broadcasts that move a call in or out of the live set. */
+  private static final List<String> EVENT_NAMES = List.of(WebConferencingService.EVENT_CALL_CREATED,
+                                                          WebConferencingService.EVENT_CALL_STARTED,
+                                                          WebConferencingService.EVENT_CALL_STOPPED);
+
+  /**
+   * Optional for the same reason as the plugin it feeds: without the
+   * Application Center there is no badge to refresh, and Web Conferencing must
+   * still start.
+   */
+  @Autowired(required = false)
+  private ApplicationBadgeService   applicationBadgeService;
+
+  /** The Kernel event bus this listener subscribes to. */
+  @Autowired
+  private ListenerService           listenerService;
+
+  /**
+   * Subscribes to the call lifecycle broadcasts, unless the Application Center
+   * is not deployed.
+   */
+  @PostConstruct
+  public void init() {
+    if (applicationBadgeService == null) {
+      LOG.debug("Application Center badge service not available, Visio badge listener not registered");
+      return;
+    }
+    EVENT_NAMES.forEach(eventName -> listenerService.addListener(eventName, this));
+  }
+
+  /**
+   * Marks the badge of every eXo user taking part in the call as stale.
+   *
+   * @param event the call lifecycle event, carrying the call as its source
+   */
+  @Override
+  public void onEvent(Event<CallInfo, Map<String, String>> event) throws Exception {
+    CallInfo call = event.getSource();
+    if (call == null || !changesLiveness(event.getEventName(), call)) {
+      return;
+    }
+    call.getParticipants()
+        .stream()
+        .filter(participant -> UserInfo.TYPE_NAME.equals(participant.getType()))
+        .map(UserInfo::getId)
+        .distinct()
+        .forEach(username -> applicationBadgeService.updateBadge(VisioApplicationBadgePlugin.BADGE_NAME, username));
+  }
+
+  /**
+   * Tells whether an event actually moved a call in or out of the live set.
+   * <p>
+   * {@code callCreated} is raised for every call, including the scheduled ones
+   * an agenda event creates hours in advance; only those created already
+   * running change anyone's count. Filtering here is what keeps a calendar full
+   * of planned visios from evicting and pushing to all their attendees.
+   *
+   * @param  eventName the broadcast name
+   * @param  call      the call carried by the event
+   * @return           {@code true} when participants' badges have to be
+   *                     refreshed
+   */
+  private boolean changesLiveness(String eventName, CallInfo call) {
+    if (WebConferencingService.EVENT_CALL_CREATED.equals(eventName)) {
+      return CallState.STARTED.equals(call.getState());
+    }
+    return true;
+  }
+
+}

--- a/services/src/main/java/org/exoplatform/webconferencing/plugin/VisioApplicationBadgePlugin.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/plugin/VisioApplicationBadgePlugin.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.webconferencing.plugin;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.webconferencing.CallState;
+import org.exoplatform.webconferencing.WebConferencingService;
+
+import io.meeds.appcenter.plugin.ApplicationBadgePlugin;
+import io.meeds.appcenter.service.ApplicationBadgePluginRegistry;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Reports how many visios are going on right now among the ones the user
+ * belongs to, on the Visio drawer tile of the Application Center.
+ * <p>
+ * Carries no counting logic of its own: it reads
+ * {@link WebConferencingService#getUserCalls(String)} — the same
+ * participant-scoped view the Visio drawer and the platform's own call buttons
+ * are built on — and keeps the rows whose state is
+ * {@link CallState#STARTED}. Badge and drawer can therefore never disagree
+ * about what is live.
+ * <p>
+ * <strong>Semantics: every started call the user belongs to</strong>, whether
+ * or not they already joined it. The nicer "only the ones I have not joined
+ * yet" variant needs one extra {@code getCall(id)} read per started call, and
+ * App Center's {@code ApplicationBadgeCounter} enforces a ~2000 ms budget with
+ * a 3-failure/60 s breaker that returns {@code 0} — a per-call fan-out inside
+ * that budget risks a badge that silently zeroes under load. This is a product
+ * decision, not a technical one, and it is one predicate either way.
+ * <p>
+ * Two known under-reports, both inherited from the underlying query and
+ * documented rather than papered over:
+ * <ul>
+ * <li>a user who joins a space <em>while</em> a call is already running gets no
+ * participant row, because participants are only ever synced when a call
+ * starts — so that call never appears in their count;</li>
+ * <li>a scheduled visio nobody has joined yet has no participant rows at all,
+ * which is intended: the badge reports what is live, not what is planned.</li>
+ * </ul>
+ */
+@Component
+@ConditionalOnClass(ApplicationBadgePlugin.class)
+public class VisioApplicationBadgePlugin implements ApplicationBadgePlugin {
+
+  /** Logger of this plugin. */
+  private static final Log               LOG        = ExoLogger.getLogger(VisioApplicationBadgePlugin.class);
+
+  /** Stable identifier of the badge, on the WebSocket frame and in the administration form. */
+  public static final String             BADGE_NAME = "visioOngoing";
+
+  /**
+   * Optional on purpose: the badge is a nicety, not something Web Conferencing
+   * depends on. When the Application Center registry is absent — a deployment
+   * without the add-on, or this module's own Spring test context — the plugin
+   * simply does not register instead of failing the whole context.
+   */
+  @Autowired(required = false)
+  private ApplicationBadgePluginRegistry applicationBadgePluginRegistry;
+
+  /**
+   * The add-on's own Service, injected through the Kernel-to-Spring bridge. It
+   * is the only source the count is derived from.
+   */
+  @Autowired
+  private WebConferencingService         webConferencingService;
+
+  /**
+   * The urls of the Application Center catalog entries pointing at the Visio
+   * drawer. Comma-separated and configurable, so a deployment that renamed or
+   * added an entry can rebind it without an administrator having to set the
+   * binding by hand. The default matches the {@code url} of the {@code visio}
+   * descriptor this add-on ships in its {@code applications.json}.
+   */
+  @Value("${webconferencing.badge.drawerNames:visio}")
+  private List<String>                   drawerNames;
+
+  /**
+   * Registers this plugin with the Application Center, unless the add-on is not
+   * deployed. Self-registration from {@code @PostConstruct} is what makes the
+   * contribution independent of the order in which the WARs boot.
+   */
+  @PostConstruct
+  public void init() {
+    if (applicationBadgePluginRegistry == null) {
+      LOG.debug("Application Center badge registry not available, Visio badge not registered");
+      return;
+    }
+    applicationBadgePluginRegistry.addPlugin(this);
+  }
+
+  /**
+   * @return the stable identifier of this badge
+   */
+  @Override
+  public String getName() {
+    return BADGE_NAME;
+  }
+
+  /**
+   * @return the {@code url} of every DRAWER catalog entry this badge binds to
+   */
+  @Override
+  public List<String> getDrawerNames() {
+    return drawerNames;
+  }
+
+  /**
+   * Counts the visios currently going on among the ones that user belongs to.
+   * <p>
+   * The underlying query joins the participants table, so it is already scoped
+   * to the queried user and returns no call they are not part of. It returns
+   * every state though — participant rows survive a call being stopped — hence
+   * the explicit {@link CallState#STARTED} predicate. It also spans every kind
+   * of call: one-to-one, space, chat room and agenda-event visios alike, which
+   * is exactly the set the drawer lists.
+   *
+   * @param  username the user the count is computed for
+   * @return          the number of ongoing visios, {@code 0} when there is none
+   *                    or when the count could not be established
+   */
+  @Override
+  public long countBadge(String username) {
+    if (StringUtils.isBlank(username)) {
+      return 0;
+    }
+    try {
+      return Arrays.stream(webConferencingService.getUserCalls(username))
+                   .filter(callState -> CallState.STARTED.equals(callState.getState()))
+                   .count();
+    } catch (Exception e) {
+      LOG.warn("Error counting ongoing visios of user {}", username, e);
+      return 0;
+    }
+  }
+
+  /**
+   * @param  username the user to test
+   * @return          {@code true} for any identified user: every user can be
+   *                    invited to a visio, so none is opted out
+   */
+  @Override
+  public boolean isEnabled(String username) {
+    return StringUtils.isNotBlank(username);
+  }
+
+}

--- a/services/src/test/java/org/exoplatform/webconferencing/listener/VisioApplicationBadgeListenerTest.java
+++ b/services/src/test/java/org/exoplatform/webconferencing/listener/VisioApplicationBadgeListenerTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.webconferencing.listener;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.webconferencing.CallInfo;
+import org.exoplatform.webconferencing.CallState;
+import org.exoplatform.webconferencing.GuestInfo;
+import org.exoplatform.webconferencing.UserInfo;
+import org.exoplatform.webconferencing.WebConferencingService;
+import org.exoplatform.webconferencing.plugin.VisioApplicationBadgePlugin;
+
+import io.meeds.appcenter.service.ApplicationBadgeService;
+
+/**
+ * The listener is glue: it must refresh every eXo participant of a call whose
+ * liveness changed, and nobody else — including on the one path that starts a
+ * call without ever broadcasting {@code callStarted}.
+ */
+@ExtendWith(MockitoExtension.class)
+class VisioApplicationBadgeListenerTest {
+
+  @Mock
+  private ApplicationBadgeService        applicationBadgeService;
+
+  @Mock
+  private ListenerService                listenerService;
+
+  @Mock
+  private CallInfo                       call;
+
+  @InjectMocks
+  private VisioApplicationBadgeListener  listener;
+
+  /**
+   * A call that starts changes the count of everyone it was synced to, not just
+   * of whoever pressed the button.
+   */
+  @Test
+  void refreshesEveryParticipantWhenACallStarts() throws Exception {
+    when(call.getParticipants()).thenReturn(participants());
+
+    listener.onEvent(event(WebConferencingService.EVENT_CALL_STARTED));
+
+    verify(applicationBadgeService).updateBadge(VisioApplicationBadgePlugin.BADGE_NAME, "mary");
+    verify(applicationBadgeService).updateBadge(VisioApplicationBadgePlugin.BADGE_NAME, "john");
+  }
+
+  /**
+   * Guests are external invitees with no Application Center to badge; pushing
+   * to them is a wasted eviction at best.
+   */
+  @Test
+  void skipsGuestParticipants() throws Exception {
+    when(call.getParticipants()).thenReturn(participants());
+
+    listener.onEvent(event(WebConferencingService.EVENT_CALL_STARTED));
+
+    verify(applicationBadgeService, never()).updateBadge(any(), eq("guest-1"));
+  }
+
+  /**
+   * The count has to drop when the last participant leaves, too.
+   */
+  @Test
+  void refreshesEveryParticipantWhenACallStops() throws Exception {
+    when(call.getParticipants()).thenReturn(participants());
+
+    listener.onEvent(event(WebConferencingService.EVENT_CALL_STOPPED));
+
+    verify(applicationBadgeService).updateBadge(VisioApplicationBadgePlugin.BADGE_NAME, "mary");
+  }
+
+  /**
+   * The bug this prevents: {@code addCall(..., start = true)} — the space call
+   * button, and every client starting a visio outright — persists the call in
+   * state {@code started} and broadcasts <strong>only</strong>
+   * {@code callCreated}. Listening to {@code callStarted} alone would leave the
+   * most common way a visio begins with no badge.
+   */
+  @Test
+  void refreshesOnACallCreatedAlreadyStarted() throws Exception {
+    when(call.getState()).thenReturn(CallState.STARTED);
+    when(call.getParticipants()).thenReturn(participants());
+
+    listener.onEvent(event(WebConferencingService.EVENT_CALL_CREATED));
+
+    verify(applicationBadgeService).updateBadge(VisioApplicationBadgePlugin.BADGE_NAME, "mary");
+  }
+
+  /**
+   * An agenda event books its visio hours in advance. Refreshing then would
+   * evict and push to every attendee of every planned meeting, for a count that
+   * did not move.
+   */
+  @Test
+  void ignoresACallCreatedButNotStarted() throws Exception {
+    when(call.getState()).thenReturn(CallState.STOPPED);
+
+    listener.onEvent(event(WebConferencingService.EVENT_CALL_CREATED));
+
+    verifyNoInteractions(applicationBadgeService);
+  }
+
+  /**
+   * The listener is asynchronous and the payload comes from another module; a
+   * missing call must not throw inside the event bus.
+   */
+  @Test
+  void toleratesAnEventWithoutACall() {
+    Event<CallInfo, java.util.Map<String, String>> event =
+                                                         new Event<>(WebConferencingService.EVENT_CALL_STARTED, null, null);
+
+    assertDoesNotThrow(() -> listener.onEvent(event));
+    verifyNoInteractions(applicationBadgeService);
+  }
+
+  /**
+   * Subscribing to the three liveness broadcasts is what makes the badge
+   * real-time; a missing one is silent staleness.
+   */
+  @Test
+  void subscribesToTheThreeLivenessEvents() {
+    listener.init();
+
+    verify(listenerService).addListener(WebConferencingService.EVENT_CALL_CREATED, listener);
+    verify(listenerService).addListener(WebConferencingService.EVENT_CALL_STARTED, listener);
+    verify(listenerService).addListener(WebConferencingService.EVENT_CALL_STOPPED, listener);
+  }
+
+  /**
+   * Without the Application Center there is no badge to refresh, and Web
+   * Conferencing must still start.
+   */
+  @Test
+  void standsDownWithoutTheApplicationCenter() {
+    ReflectionTestUtils.setField(listener, "applicationBadgeService", null);
+
+    assertDoesNotThrow(() -> listener.init());
+    verifyNoInteractions(listenerService);
+  }
+
+  /**
+   * @param  eventName the broadcast name to simulate
+   * @return           an event shaped like {@code broacastCallEvent} builds
+   *                     them: the call as source, the metric map as data
+   */
+  private Event<CallInfo, java.util.Map<String, String>> event(String eventName) {
+    return new Event<>(eventName, call, java.util.Map.of("user_id", "mary"));
+  }
+
+  /**
+   * @return a participant set mixing eXo users and an external guest, as a
+   *           started call with an invited external has
+   */
+  private Set<UserInfo> participants() {
+    Set<UserInfo> participants = new LinkedHashSet<>();
+    participants.add(new UserInfo("mary", "Mary", "Kelly"));
+    participants.add(new UserInfo("john", "John", "Smith"));
+    participants.add(new GuestInfo("guest-1"));
+    return participants;
+  }
+
+}

--- a/services/src/test/java/org/exoplatform/webconferencing/plugin/VisioApplicationBadgePluginTest.java
+++ b/services/src/test/java/org/exoplatform/webconferencing/plugin/VisioApplicationBadgePluginTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.webconferencing.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import org.exoplatform.webconferencing.CallState;
+import org.exoplatform.webconferencing.WebConferencingService;
+import org.exoplatform.webconferencing.dao.StorageException;
+
+import io.meeds.appcenter.service.ApplicationBadgePluginRegistry;
+
+/**
+ * The badge must report exactly the calls the Visio drawer shows as live, and
+ * must never keep Web Conferencing from starting when App Center is absent.
+ */
+@ExtendWith(MockitoExtension.class)
+class VisioApplicationBadgePluginTest {
+
+  private static final String            USERNAME = "testuser";
+
+  @Mock
+  private ApplicationBadgePluginRegistry registry;
+
+  @Mock
+  private WebConferencingService         webConferencingService;
+
+  @InjectMocks
+  private VisioApplicationBadgePlugin    plugin;
+
+  /**
+   * Participant rows survive a call being stopped, so the query returns stopped
+   * and paused calls too. Counting them would show a badge for visios that
+   * ended hours ago.
+   */
+  @Test
+  void countsOnlyStartedCalls() throws Exception {
+    when(webConferencingService.getUserCalls(USERNAME)).thenReturn(new CallState[] {
+        new CallState("call-1", CallState.STARTED), new CallState("call-2", CallState.STOPPED),
+        new CallState("call-3", CallState.STARTED), new CallState("call-4", CallState.PAUSED) });
+
+    assertEquals(2L, plugin.countBadge(USERNAME));
+  }
+
+  /**
+   * A user with participant rows but no live call must show no badge at all,
+   * not an empty one.
+   */
+  @Test
+  void countsZeroWhenNothingIsLive() throws Exception {
+    when(webConferencingService.getUserCalls(USERNAME)).thenReturn(new CallState[] {
+        new CallState("call-1", CallState.STOPPED) });
+
+    assertEquals(0L, plugin.countBadge(USERNAME));
+  }
+
+  /**
+   * A storage failure must degrade to "no badge", never propagate: the counter
+   * runs on the read path of every application tile.
+   */
+  @Test
+  void countsZeroWhenTheCallStorageFails() throws Exception {
+    when(webConferencingService.getUserCalls(USERNAME)).thenThrow(new StorageException("boom"));
+
+    assertEquals(0L, plugin.countBadge(USERNAME));
+  }
+
+  /**
+   * The count is per user; a blank username must not reach the storage at all.
+   */
+  @Test
+  void countsZeroForABlankUsernameWithoutQuerying() throws Exception {
+    assertEquals(0L, plugin.countBadge("  "));
+
+    verify(webConferencingService, never()).getUserCalls(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  /**
+   * App Center owns the caching: declaring self-caching without owning a cache
+   * and its single-flight would put an uncached query on every tile render.
+   */
+  @Test
+  void isNotSelfCachedSoAppCenterOwnsTheCaching() {
+    assertFalse(plugin.isSelfCached());
+  }
+
+  /**
+   * Everyone can be invited to a visio, so nobody is opted out — but an
+   * unidentified caller still is.
+   */
+  @Test
+  void isEnabledForAnyIdentifiedUser() {
+    assertTrue(plugin.isEnabled(USERNAME));
+    assertFalse(plugin.isEnabled(""));
+  }
+
+  /**
+   * The drawer binding is one string, and it has to be the {@code url} of the
+   * {@code visio} descriptor: a mismatch resolves to no badge, silently.
+   */
+  @Test
+  void declaresItsDrawerBinding() {
+    ReflectionTestUtils.setField(plugin, "drawerNames", List.of("visio"));
+
+    assertEquals(List.of("visio"), plugin.getDrawerNames());
+    assertEquals(VisioApplicationBadgePlugin.BADGE_NAME, plugin.getName());
+  }
+
+  /**
+   * Self-registration is what makes the contribution independent of WAR boot
+   * order.
+   */
+  @Test
+  void registersItselfWhenTheRegistryIsPresent() {
+    plugin.init();
+
+    verify(registry).addPlugin(plugin);
+  }
+
+  /**
+   * The badge is a nicety: a deployment without App Center must still boot Web
+   * Conferencing.
+   */
+  @Test
+  void startsWithoutTheApplicationCenterRegistry() {
+    ReflectionTestUtils.setField(plugin, "applicationBadgePluginRegistry", null);
+
+    assertDoesNotThrow(() -> plugin.init());
+  }
+
+}

--- a/webapp/src/main/java/org/exoplatform/webconferencing/WebConferencingApplication.java
+++ b/webapp/src/main/java/org/exoplatform/webconferencing/WebConferencingApplication.java
@@ -19,6 +19,7 @@
 package org.exoplatform.webconferencing;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.context.annotation.PropertySource;
 
 import io.meeds.spring.AvailableIntegration;
@@ -51,9 +52,28 @@ import io.meeds.spring.kernel.PortalApplicationContextInitializer;
  * Spring context before this one ({@code agenda}, {@code email-connector})
  * declares it. Dropping it would leave Spring Boot's default security
  * auto-configuration unadjusted over this WAR's existing url space.
+ * <p>
+ * {@code LiquibaseAutoConfiguration} is excluded, and the exclusion is what
+ * actually enforces the "no second schema bootstrap" intent. Declining to list
+ * {@code LIQUIBASE_MODULE} in the scan is not enough: Spring Boot
+ * auto-configuration triggers on what is present on the <em>classpath</em>, not
+ * on what is scanned, and Liquibase is on every platform's classpath. Left
+ * alone it looks for its default {@code db/changelog/db.changelog-master.yaml},
+ * does not find one here, and fails the {@code liquibase} bean — which fails
+ * {@code entityManagerFactory} behind it, stops this context, and through the
+ * Kernel/Spring bridge takes the portal itself to a 500. Observed on a running
+ * server, not theorised. {@code agenda} excludes the same configuration.
+ * <p>
+ * The JPA auto-configuration is deliberately <em>not</em> excluded, even though
+ * this add-on owns no Spring-managed entity. Removing it was tried and broke
+ * the boot differently: the platform modules scanned above expect an
+ * {@code entityManagerFactory} to exist ({@code jpaSharedEM_entityManagerFactory}
+ * resolves against it), so denying them one merely swaps a Liquibase failure
+ * for a missing-bean one. The add-on continues to manage its own schema through
+ * the Kernel regardless; the factory simply goes unused here.
  */
 @SpringBootApplication(scanBasePackages = { WebConferencingApplication.MODULE_NAME, AvailableIntegration.KERNEL_MODULE,
-    AvailableIntegration.WEB_MODULE })
+    AvailableIntegration.WEB_MODULE }, exclude = { LiquibaseAutoConfiguration.class })
 @PropertySource("classpath:application.properties")
 @PropertySource("classpath:application-common.properties")
 public class WebConferencingApplication extends PortalApplicationContextInitializer {

--- a/webapp/src/main/java/org/exoplatform/webconferencing/WebConferencingApplication.java
+++ b/webapp/src/main/java/org/exoplatform/webconferencing/WebConferencingApplication.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.webconferencing;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.PropertySource;
+
+import io.meeds.spring.AvailableIntegration;
+import io.meeds.spring.kernel.PortalApplicationContextInitializer;
+
+/**
+ * Spring Boot bootstrap of the Web Conferencing webapp.
+ * <p>
+ * Web Conferencing has historically been a pure eXo Kernel add-on with no
+ * Spring context at all. It gets one here for a single reason: contributing an
+ * Application Center badge means contributing a Spring bean, and a bean needs a
+ * context to live in. Extending {@link PortalApplicationContextInitializer}
+ * registers this WAR's context with the Kernel before the portal container
+ * boots, so beans of this add-on and of the platform become mutually
+ * injectable — which is how {@code VisioApplicationBadgePlugin} can
+ * {@code @Autowired} the Kernel-side {@link WebConferencingService}.
+ * <p>
+ * The scan is deliberately narrow. Only {@link #MODULE_NAME} is scanned, and
+ * every class currently shipped under that package by this add-on, by
+ * {@code web-conferencing-jitsi} and by {@code external-visio-connector}
+ * carries no Spring annotation whatsoever — so this context registers the badge
+ * plugin and its listener, and nothing else. No JPA and no Liquibase
+ * integration is declared: this add-on keeps managing its own schema through
+ * the Kernel, and pulling those in would put a second, competing persistence
+ * bootstrap in front of it.
+ * <p>
+ * {@code AvailableIntegration.WEB_MODULE} is kept even though no Spring MVC
+ * endpoint is exposed: it carries the platform's own web security, locale and
+ * transaction filter configuration, and every legacy Kernel WAR that took a
+ * Spring context before this one ({@code agenda}, {@code email-connector})
+ * declares it. Dropping it would leave Spring Boot's default security
+ * auto-configuration unadjusted over this WAR's existing url space.
+ */
+@SpringBootApplication(scanBasePackages = { WebConferencingApplication.MODULE_NAME, AvailableIntegration.KERNEL_MODULE,
+    AvailableIntegration.WEB_MODULE })
+@PropertySource("classpath:application.properties")
+@PropertySource("classpath:application-common.properties")
+public class WebConferencingApplication extends PortalApplicationContextInitializer {
+
+  /**
+   * Base package of the add-on, and the only root this context scans.
+   */
+  public static final String MODULE_NAME = "org.exoplatform.webconferencing";
+
+}

--- a/webapp/src/main/resources/locale/addon/appcenter_en.properties
+++ b/webapp/src/main/resources/locale/addon/appcenter_en.properties
@@ -1,2 +1,3 @@
 appCenter.system.application.visio=Visio
 appCenter.system.application.visio.description=Join your ongoing and upcoming visios
+appCenter.adminSetupForm.badge.visioOngoing=Ongoing visios


### PR DESCRIPTION
Contributes an App Center badge showing ongoing visios, via the eXIP 48140 SPI. Stacked on #390.

**This is N1 and is not ready to merge on AI review.** It adds a **Spring context to a legacy Kernel WAR** — squarely the Kernel/Spring bridge socle trigger — and changes the boot behaviour of a widely deployed add-on. Human Archi/Dev pass required, author ≠ approver.

**It took the portal down twice during testing, from causes no test caught.** Spring Boot's `LiquibaseAutoConfiguration` fires on *classpath* presence, not on what you scan: it looked for a default changelog that does not exist here, failed the `liquibase` bean, failed `entityManagerFactory` behind it, stopped the context, and through the Kernel/Spring bridge took `/portal` to 500 on every page. Excluding it (as `agenda` does) fixes it; excluding the JPA auto-configuration as well is wrong, and the commit says why.

**Two things a reviewer should look at first**, both flagged by the author rather than discovered:
1. **`AvailableIntegration.WEB_MODULE` is kept** even though no Spring MVC endpoint is exposed. It carries a `SecurityFilterChain` over this WAR's URL space. The reasoning is that dropping it leaves Spring Boot's *default* security auto-configuration unadjusted instead — but this is the single least-certain line in the diff.
2. **An actual boot on an acceptance server.** Every failure mode here is a startup failure; the build, the 17 tests and the packaged artifacts all stayed green while the portal was down.

Verified: the scan is provably narrow (every deployed jar under `org.exoplatform.webconferencing` was unzipped and grepped — zero Spring annotations, so this context registers two beans and nothing else); boot order holds (web-conferencing 150 > app-center 21); `web.xml` needs no surgery.

Known and documented in the code: a user joining a space *during* a call is not counted until a resync; two paths change liveness without broadcasting, left to the 300s cache TTL.