### PR TITLE
fix: a chat room created without being started admits nobody EXO-89442

### DIFF
--- a/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
+++ b/services/src/main/java/org/exoplatform/webconferencing/WebConferencingService.java
@@ -2704,6 +2704,21 @@ public class WebConferencingService implements Startable {
                   .filter(p -> !GuestInfo.TYPE_NAME.equals(p.getType()))
                   .map(p -> p.getId())
                   .toArray(String[]::new);
+          if (members.length == 0) {
+            // A room created without starting it has no participant row yet:
+            // txCreateCall() only syncs members and participants of a group call
+            // created already started, and addCall() builds the owner with empty
+            // members otherwise. Reading its members back from those same rows
+            // therefore returns nobody, and the one who opened the room is
+            // refused entry to it. Falling back to the origins is what the space
+            // event branch below already does, and the note it carries — that
+            // origins would be useful for all types of calls — is exactly this
+            // case.
+            members = originsStorage.findCallOrigins(callId, OWNER_TYPE_USER)
+                    .stream()
+                    .map(o -> o.getId())
+                    .toArray(String[]::new);
+          }
           owner = roomInfo(ownerId, roomTitle, members, callId);
         } else {
           LOG.warn("Saved call doesn't have room settings: '" + settings + "'");


### PR DESCRIPTION
Creating a group call **without starting it** leaves nobody able to enter it — including the person who created it.

Three pieces of `WebConferencingService` combine:

- `addCall` builds the owner with empty members on that path — *"for just creating call, we use as it was - owner with empty members"*
- `txCreateCall` syncs members into participant rows **only** when the call is created already `STARTED`
- `readCallEntity` derives a chat room's members **from those same participant rows**

Members are read from rows that are written from members, so the call comes back with nobody in it and the join is refused with *"User is not allowed for this call"*.

Nothing hit this before because a call was always created already started — the chat app does. Opening a room and entering it later is new (instant visio rooms, EXO-89433).

**What hid it:** following the room's own invitation admits the opener as a *guest*. Every participant row of such a room therefore read `guest`, the room counted in nobody's badge, and it displayed nobody while somebody was sitting in it. Those looked like three separate bugs in the drawer and the badge — they were this one.

## The fix

Members fall back to the call's `user` origins when no participant row exists yet. That is what the `space_event` branch immediately below already does, and the note it carries — *"the origins would be useful for all types of calls"* — is exactly this case. The first join then syncs those members into real participant rows.

## Testing

Verified on a local platform against **all four owner types**, reading `WBC_PARTICIPANTS` rows and badge behaviour directly rather than judging from the UI:

| Flow | Owner type | Result |
|---|---|---|
| 1:1 chat call | `user` | both parties written `user`, unchanged |
| Space call | `space` | two participants, full join/leave/stop cycle, unchanged |
| Event visio | `space_event` | unchanged |
| Instant room | `chat_room` | now writes a `user` participant row — previously `guest`, or refused entry |

Only a chat-room call with **zero** participants reaches the new branch, and such a call is unusable today.

## Review note

This touches a core service read path shared by every call type — **N2**, please review as a platform fix rather than as part of the visio drawer work. It is deliberately split out of EXO-89428 for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)