### PR TITLE
fix: join a room you opened as yourself, and keep the list truthful EXO-89433

### DIFF
--- a/webapp/src/main/resources/locale/portlet/visio/Visio_en.properties
+++ b/webapp/src/main/resources/locale/portlet/visio/Visio_en.properties
@@ -63,4 +63,3 @@ visio.drawer.peopleInWithGuests={0} in the room, {1} guest(s)
 visio.drawer.openEventTitle=Open the event: {0}
 visio.drawer.sendByMail.unavailable=The mail composer could not be opened.
 visio.drawer.joinTitle=Join: {0}
-visio.drawer.backToRoom=Back to the room

--- a/webapp/src/main/resources/locale/portlet/visio/Visio_en.properties
+++ b/webapp/src/main/resources/locale/portlet/visio/Visio_en.properties
@@ -62,3 +62,5 @@ visio.drawer.nobodyIn=Nobody has joined yet
 visio.drawer.peopleInWithGuests={0} in the room, {1} guest(s)
 visio.drawer.openEventTitle=Open the event: {0}
 visio.drawer.sendByMail.unavailable=The mail composer could not be opened.
+visio.drawer.joinTitle=Join: {0}
+visio.drawer.backToRoom=Back to the room

--- a/webapp/src/main/webapp/vue-apps/VisioDrawer/components/VisioCard.vue
+++ b/webapp/src/main/webapp/vue-apps/VisioDrawer/components/VisioCard.vue
@@ -47,19 +47,25 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
         </v-chip>
         <span class="text-caption text-sub-title">{{ timeLabel }}</span>
       </div>
-      <!-- The title goes to the event the visio belongs to, and nowhere else.
-           It reads as clickable — bold, and carrying a tooltip — so it had
-           better do something; but it must not be the way into the room.
-           Entering marks the call started, which is why the join button is
-           withheld on a meeting still days away, and a title that joined would
-           hand back the mis-click that guard exists to prevent. Opening the
-           event is safe whenever it is possible, and is the thing a title is
-           actually about. Instant rooms have no event, so theirs stays plain
-           text rather than pretending. -->
+      <!-- The title does the one thing that makes sense for the state it is
+           in. Where joining is on offer it joins, matching the button beside
+           it. Where it is not — a meeting still days away — it opens the event
+           instead, which is safe: entering a room marks its call started, and a
+           title that joined a meeting next week would hand back exactly the
+           mis-click the join guard exists to prevent. With neither, it is plain
+           text and looks it; a heading that cannot be clicked must not invite
+           the click. -->
       <v-tooltip bottom>
         <template #activator="{on, attrs}">
           <a
-            v-if="eventLink"
+            v-if="canJoin"
+            v-bind="attrs"
+            class="text-body font-weight-bold mt-2 text-truncate d-block text-color"
+            href="#"
+            v-on="on"
+            @click.prevent="join">{{ title }}</a>
+          <a
+            v-else-if="eventLink"
             v-bind="attrs"
             :href="eventLink"
             class="text-body font-weight-bold mt-2 text-truncate d-block text-color"
@@ -70,20 +76,20 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
             class="text-body font-weight-bold mt-2 text-truncate"
             v-on="on">{{ title }}</div>
         </template>
-        <span>{{ eventLink && $t('visio.drawer.openEventTitle', {0: title}) || title }}</span>
+        <span>{{ titleHint }}</span>
       </v-tooltip>
       <!-- How long it has been running, not how far through it is. A meeting's
            end time is a plan rather than a fact: they overrun, and a progress
            bar is wrong exactly when someone most wants to know. The accent
            stripe already carries the "this is live" signal a bar would repeat. -->
       <div
-        v-if="showProgress"
+        v-if="showProgress && hasFooterContent"
         class="text-caption text-sub-title mt-2">
         <v-icon size="12" class="me-1">fa-circle-play</v-icon>
         {{ progressLabel }}
       </div>
       <div
-        v-else-if="countdown"
+        v-else-if="countdown && hasFooterContent"
         class="text-caption text-sub-title mt-2">
         <v-icon size="12" class="me-1">fa-clock</v-icon>
         {{ countdownLabel }}
@@ -100,7 +106,17 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
              resolve — it would ask the server for one and come back with
              nothing. They are counted instead, which is also the more useful
              fact about them. -->
-        <div v-if="people.length" class="d-flex align-center">
+        <!-- With nobody inside and no join to offer, the meta line moves in here
+             rather than standing on a row of its own: otherwise the overflow
+             button is marooned on an empty line and the card grows a band of
+             white space for nothing. -->
+        <div
+          v-if="!hasFooterContent"
+          class="text-caption text-sub-title">
+          <v-icon size="12" class="me-1">{{ showProgress && 'fa-circle-play' || 'fa-clock' }}</v-icon>
+          {{ showProgress && progressLabel || countdownLabel }}
+        </div>
+        <div v-else-if="people.length" class="d-flex align-center">
           <exo-user-avatars-list
             v-if="members.length"
             :users="members"
@@ -154,6 +170,14 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
               </v-btn>
             </template>
             <v-list class="pa-0" dense>
+              <v-list-item v-if="eventLink" :href="eventLink">
+                <v-list-item-icon class="me-2 my-2">
+                  <v-icon size="16">fas fa-calendar-day</v-icon>
+                </v-list-item-icon>
+                <v-list-item-title>
+                  {{ $t('visio.drawer.openEvent') }}
+                </v-list-item-title>
+              </v-list-item>
               <v-list-item v-if="entry.shareUrl" @click="copyLink">
                 <v-list-item-icon class="me-2 my-2">
                   <v-icon size="16">{{ copied && 'fas fa-check' || 'fas fa-link' }}</v-icon>
@@ -338,7 +362,7 @@ export default {
      * @returns {Boolean} true when the menu should be offered
      */
     hasMenu() {
-      return !!this.entry.shareUrl || this.deletable;
+      return !!this.entry.shareUrl || this.deletable || !!this.eventLink;
     },
     /**
      * The people actually in the room right now.
@@ -420,6 +444,27 @@ export default {
     deletable() {
       return !!this.entry.instant && this.entry.state === READY && !this.people.length;
     },
+    /**
+     * What the tooltip says the title will do, so the promise is legible before
+     * the click rather than after it.
+     *
+     * @returns {String} the hint for this card's title
+     */
+    titleHint() {
+      return this.canJoin && this.$t('visio.drawer.joinTitle', {0: this.title})
+          || this.eventLink && this.$t('visio.drawer.openEventTitle', {0: this.title})
+          || this.title;
+    },
+    /**
+     * Whether the footer row already has something on its left: people inside,
+     * or the line saying nobody is. When it does not, the meta line moves down
+     * into it rather than leaving the overflow button alone on a row.
+     *
+     * @returns {Boolean} true when the footer has its own left-hand content
+     */
+    hasFooterContent() {
+      return this.people.length > 0 || this.showsEmptyRoom;
+    },
     prominent() {
       return this.entry.state === LIVE || this.entry.state === NOW;
     },
@@ -456,8 +501,20 @@ export default {
      *
      * @returns {String} the translated label
      */
+    /**
+     * Whether the viewer is one of the people already in the room.
+     *
+     * @returns {Boolean} true when the current user is joined
+     */
+    alreadyIn() {
+      const me = eXo && eXo.env && eXo.env.portal && eXo.env.portal.userName;
+      return !!me && this.people.some(person => person.id === me);
+    },
     joinLabel() {
-      return this.entry.state === NOW
+      // Already inside: the room is open in another tab, so the button brings
+      // it back rather than pretending this is an arrival.
+      return this.alreadyIn && this.$t('visio.drawer.backToRoom')
+          || this.entry.state === NOW
           && this.$t('visio.drawer.join.first')
           || this.$t('visio.drawer.join');
     },

--- a/webapp/src/main/webapp/vue-apps/VisioDrawer/components/VisioCard.vue
+++ b/webapp/src/main/webapp/vue-apps/VisioDrawer/components/VisioCard.vue
@@ -501,20 +501,8 @@ export default {
      *
      * @returns {String} the translated label
      */
-    /**
-     * Whether the viewer is one of the people already in the room.
-     *
-     * @returns {Boolean} true when the current user is joined
-     */
-    alreadyIn() {
-      const me = eXo && eXo.env && eXo.env.portal && eXo.env.portal.userName;
-      return !!me && this.people.some(person => person.id === me);
-    },
     joinLabel() {
-      // Already inside: the room is open in another tab, so the button brings
-      // it back rather than pretending this is an arrival.
-      return this.alreadyIn && this.$t('visio.drawer.backToRoom')
-          || this.entry.state === NOW
+      return this.entry.state === NOW
           && this.$t('visio.drawer.join.first')
           || this.$t('visio.drawer.join');
     },

--- a/webapp/src/main/webapp/vue-apps/VisioDrawer/components/VisioInstantPanel.vue
+++ b/webapp/src/main/webapp/vue-apps/VisioDrawer/components/VisioInstantPanel.vue
@@ -120,11 +120,21 @@ export default {
     },
     /**
      * Opens the room in a new tab.
+     * <p>
+     * The plain room address, never the share link: the two differ by an
+     * {@code inviteId}, and that parameter is what makes the platform admit
+     * somebody as a guest. Following one's own invitation would register the
+     * person who opened the room as a guest of it — no participant row of type
+     * user, so the room counts for nobody and no badge is raised for the one
+     * person certainly in it. The share link stays what it is for: other people.
      *
      * @returns {void}
      */
     join() {
-      window.open(this.room.shareUrl || this.room.url, '_blank', 'noopener');
+      const own = this.room.url || this.room.shareUrl || '';
+      const invite = own.indexOf('inviteId=');
+      const cut = invite > 0 && own.lastIndexOf('?', invite) || -1;
+      window.open(cut > 0 && own.substring(0, cut) || own, '_blank', 'noopener');
     },
     /**
      * Selects the whole link, so it can be copied by hand wherever the

--- a/webapp/src/main/webapp/vue-apps/VisioDrawer/js/VisioInstant.js
+++ b/webapp/src/main/webapp/vue-apps/VisioDrawer/js/VisioInstant.js
@@ -145,6 +145,24 @@ export function removeRoom(userName, callId, now) {
  * @param {Array} startedIds - the ids of the calls that are started
  * @returns {Array} the entries to merge into the drawer list
  */
+/**
+ * The same address with any invitation dropped.
+ *
+ * @param  {string} url - a room address, with or without an invitation
+ * @returns {string} the address nobody is admitted as a guest through
+ */
+function withoutInvite(url) {
+  if (!url) {
+    return '';
+  }
+  const invite = url.indexOf('inviteId=');
+  if (invite < 0) {
+    return url;
+  }
+  const cut = url.lastIndexOf('?', invite);
+  return cut > 0 && url.substring(0, cut) || url;
+}
+
 export function instantEntries(rooms, startedIds) {
   const started = startedIds || [];
   return (rooms || []).map(room => ({
@@ -155,7 +173,17 @@ export function instantEntries(rooms, startedIds) {
     start: new Date(room.createdAt),
     end: null,
     allDay: false,
-    url: room.shareUrl || room.url || '',
+    // Two addresses that must not be confused. `url` is where the button takes
+    // the owner of the room, `shareUrl` is what they hand to somebody else, and
+    // they differ by the `inviteId` that tells the platform to admit whoever
+    // follows it as a guest — an eXo user following one is added as a guest of
+    // the call just the same. Opening it yourself means no participant row of
+    // type user: the room counts in nobody's badge and shows nobody in it,
+    // while you sit in it. Stripped rather than merely preferred, because a
+    // room remembered before this was understood has the invitation in both
+    // fields, and the poisoned participant row it creates is keyed by
+    // (user, call) — so it is written once and never corrects itself.
+    url: withoutInvite(room.url || room.shareUrl || ''),
     shareUrl: room.shareUrl || room.url || '',
     providerType: room.providerType || '',
     callId: room.callId,

--- a/webapp/src/main/webapp/vue-apps/VisioDrawer/js/VisioRefreshMixin.js
+++ b/webapp/src/main/webapp/vue-apps/VisioDrawer/js/VisioRefreshMixin.js
@@ -56,6 +56,7 @@ export default {
         this.ticker = window.setInterval(() => this.now = new Date(), TICK_MS);
       }
       document.addEventListener('visibilitychange', this.onVisibilityChange);
+      window.addEventListener('focus', this.onWindowFocus);
       if (!this.subscription) {
         this.$visioService.getWebConferencing()
           .then(core => {
@@ -76,6 +77,7 @@ export default {
         this.ticker = null;
       }
       document.removeEventListener('visibilitychange', this.onVisibilityChange);
+      window.removeEventListener('focus', this.onWindowFocus);
       if (this.subscription) {
         this.subscription.off();
         this.subscription = null;
@@ -111,6 +113,25 @@ export default {
     onVisibilityChange() {
       if (!document.hidden && this.drawer) {
         this.refresh();
+      }
+    },
+    /**
+     * Refreshes when this window is focused again.
+     * <p>
+     * A call opens in a window of its own, and joining a room that is merely
+     * ready is what brings it to life — through a path that deliberately
+     * notifies nobody, so no push ever announces it. Coming back to the portal
+     * beside an open call window does not hide this tab either, so
+     * {@code visibilitychange} stays silent and the drawer would go on showing
+     * a room as ready while the viewer sits in it. Focus is the one moment the
+     * list is looked at again, so it is the moment to make it true.
+     *
+     * @returns {void}
+     */
+    onWindowFocus() {
+      if (this.drawer) {
+        // Same coalescing as a push: focus and a call update often land together.
+        this.onCallUpdate();
       }
     },
   },


### PR DESCRIPTION
Opening a room on the fly then joining it left the room live but empty, raised no badge, and refused entry once the invitation stopped being handed out.

## Joining your own room

The button followed the room's **share link**. That link differs from the room's address by an `inviteId`, and an `inviteId` is what tells the platform to admit whoever follows it as a guest — an eXo user included:

```js
if (inviteId) {
  // exo user with invite link
  inviteInCall(userinfo, $promise);   // → addGuest(callId, userinfo.id)
}
```

So the person who opened the room was registered as a *guest* of it, with no participant row of type `user`: the room counted in nobody's badge and showed nobody in it, while they sat in it. Both entry points did this, and `instantEntries` collapsed both addresses into the same value:

```js
url:      room.shareUrl || room.url || '',   // the button
shareUrl: room.shareUrl || room.url || '',   // what you hand to others
```

Preferring one field over the other is not enough when both hold the same value, so the invitation is **stripped** — which also repairs rooms remembered before this was understood.

## Two smaller things

- **"Back to the room" is gone.** The label was derived from the people on the card, which on a calendar event are the *invited* rather than the *present*, so it promised a room the viewer had never entered. Plain "Join" is honest in both cases.
- **The drawer refreshes when its window regains focus.** A call opens in a window of its own, so the portal tab never hides and `visibilitychange` stays silent — while the join that brings a ready room to life notifies nobody by design. Coalesced through the same debounce as pushes.

## Testing

Verified on a local platform: creating a room and joining it once now writes `('root', 'g_visio-…', 'user', 'joined', …)` where it previously wrote `guest`, with Live and the badge following on that first join. Also checked that 1:1 chat, space and event calls are unaffected.

Best read alongside EXO-89442 (#394), which fixes why such a room had no members to admit anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)