### PR TITLE
fix: declare the coverage floor this module never had EXO-89435

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -34,6 +34,15 @@
   <description>eXo Web Conferencing services of portal extension</description>
 
   <properties>
+    <!-- The parent's default is 1.0, a hundred percent, which this module has
+         never met: until the badge arrived it had no tests at all, and it still
+         has seventeen against a hundred and eighteen classes. Every sibling
+         add-on declares this explicitly rather than inheriting the default -
+         caldav and agenda's api modules at 0, agenda-services at 0.64,
+         email-connector-services at 0.5. Zero is the honest floor here today;
+         raise it to just under the real figure once a green build reports one,
+         so the number means something rather than staying switched off. -->
+    <exo.test.coverage.ratio>0</exo.test.coverage.ratio>
     <rest.api.doc.title>WebConferencing Rest Api</rest.api.doc.title>
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>WebConferencing addon rest endpoints</rest.api.doc.description>


### PR DESCRIPTION
Backports the feature branch's `91243f8b` onto develop. `Tested & Validated` on the board. One property in `services/pom.xml`.

### What it does

The parent POM's default `exo.test.coverage.ratio` is **1.0** — a hundred percent — which this module has never met and cannot: seventeen tests against a hundred and eighteen classes on the feature branch, and **zero tests on develop today**. Every sibling add-on declares the figure explicitly rather than inheriting that default (`caldav` and `agenda`'s api modules at 0, `agenda-services` at 0.64, `email-connector-services` at 0.5).

### Read this before approving: it is preventive, not corrective

**develop's build is green as it stands.** `services` carries no test at all, so the rule never fires. I verified both sides — `mvn package` on develop alone: `BUILD SUCCESS`; with this change: `BUILD SUCCESS`.

It starts mattering the moment a test arrives in this module — which is what the visio badge work (EXO-89428) brings — and the failure it then produces is a build stopping on a threshold nobody chose.

So this lands a **declaration**, not a fix, and it deliberately relaxes an inherited gate from 100% to 0. Zero is the honest floor for today; it should be raised to just under the real figure once a green build reports one, so the number means something rather than staying switched off. If you'd rather set it to the real coverage now and have the badge PR raise it, say so — that's a one-line change.

### Verification

`mvn package` on `web-conferencing`: **BUILD SUCCESS**. Applies on develop with no conflict, and depends on nothing else queued — unlike EXO-89428/89433, which only build as a group with the still-unvalidated EXO-89427 and are therefore not being backported.

---

**Classification: N2.** No code, no ACL, no schema — but it lowers a quality gate's threshold, which is exactly the kind of change that should not pass on an AI review alone. One human ack, please.
